### PR TITLE
Consolidate SQLite lookups into JOIN queries

### DIFF
--- a/src/Catalog.ServiceComposition/Email/OrderSummary.cs
+++ b/src/Catalog.ServiceComposition/Email/OrderSummary.cs
@@ -17,16 +17,18 @@ public class OrderSummary(CatalogDbContext dbContext) : ICompositionRequestsHand
         var orderData = await request.Bind<OrderData>();
         var ct = request.HttpContext.RequestAborted;
 
-        var order = await dbContext.Orders
-            .Include(o => o.Products)
-            .SingleAsync(s => s.OrderId == orderData.OrderId, ct);
+        var rows = await (
+            from o in dbContext.Orders
+            from i in o.Products
+            join p in dbContext.Products on i.ProductId equals p.ProductId
+            where o.OrderId == orderData.OrderId
+            select new { OrderItem = i, Product = p }).ToListAsync(ct);
 
-        var productIds = order.Products.Select(s => s.ProductId).ToList();
-        var products = await dbContext.Products
-            .Where(s => productIds.Contains(s.ProductId))
-            .ToListAsync(ct);
-
-        var productsModel = MapToDictionary(order.Products, products);
+        var productsModel = new Dictionary<Guid, dynamic>();
+        foreach (var row in rows)
+        {
+            productsModel[row.OrderItem.ProductId] = MapToViewModel(row.OrderItem, row.Product);
+        }
 
         var context = request.GetCompositionContext();
         await context.RaiseEvent(new ProductsLoaded
@@ -37,21 +39,6 @@ public class OrderSummary(CatalogDbContext dbContext) : ICompositionRequestsHand
         var vm = request.GetComposedResponseModel();
         vm.Products = productsModel.Values.ToList();
         vm.OrderId = orderData.OrderId;
-    }
-
-    public IDictionary<Guid, dynamic> MapToDictionary(IEnumerable<OrderItem> orderedProducts, List<Product> products)
-    {
-        var productsViewModel = new Dictionary<Guid, dynamic>();
-
-        foreach (var orderedProduct in orderedProducts)
-        {
-            var product = products.Single(s => s.ProductId == orderedProduct.ProductId);
-            var vm = MapToViewModel(orderedProduct, product);
-
-            productsViewModel[orderedProduct.ProductId] = vm;
-        }
-
-        return productsViewModel;
     }
 
     private dynamic MapToViewModel(OrderItem orderedProduct, Product product)

--- a/src/Catalog.ServiceComposition/Products/ProductHandler.cs
+++ b/src/Catalog.ServiceComposition/Products/ProductHandler.cs
@@ -19,10 +19,13 @@ public class ProductHandler(CatalogDbContext dbContext) : ICompositionRequestsHa
         var productId = Guid.Parse(productIdString);
 
         var ct = request.HttpContext.RequestAborted;
-        var product = await dbContext.Products.SingleAsync(s => s.ProductId == productId, ct);
-        var inventoryItem = await dbContext.InventorySnapshots.SingleAsync(s => s.ProductId == productId, ct);
+        var row = await (
+            from p in dbContext.Products
+            join s in dbContext.InventorySnapshots on p.ProductId equals s.ProductId
+            where p.ProductId == productId
+            select new { Product = p, Inventory = s }).SingleAsync(ct);
 
-        var productModel = Mapper.MapToViewModel(product, inventoryItem);
+        var productModel = Mapper.MapToViewModel(row.Product, row.Inventory);
 
         var context = request.GetCompositionContext();
         await context.RaiseEvent(new ProductLoaded

--- a/src/Finance.Endpoint/Handlers/SubmitOrderItemsHandler.cs
+++ b/src/Finance.Endpoint/Handlers/SubmitOrderItemsHandler.cs
@@ -24,12 +24,16 @@ public class SubmitOrderItemsHandler(FinanceDbContext dbContext) : IHandleMessag
             order.Items.Clear();
         }
 
+        // NOTE: Never ever do this! Don't retrieve _current_ price after submitting the order.
+        // Instead, use attached PriceId. But that isn't implemented yet.
+        var productIds = message.Items.Select(i => i.ProductId).ToList();
+        var products = await dbContext.Products
+            .Where(p => productIds.Contains(p.ProductId))
+            .ToDictionaryAsync(p => p.ProductId, context.CancellationToken);
+
         foreach (var item in message.Items)
         {
-            // NOTE: Never ever do this! Don't retrieve _current_ price after submitting the order.
-            // Instead, use attached PriceId. But that isn't implemented yet.
-            var product = await dbContext.Products
-                .SingleAsync(s => s.ProductId == item.ProductId, context.CancellationToken);
+            var product = products[item.ProductId];
             order.Items.Add(new OrderItem
             {
                 ProductId = item.ProductId,

--- a/src/Finance.ServiceComposition/Email/OrderSummary.cs
+++ b/src/Finance.ServiceComposition/Email/OrderSummary.cs
@@ -18,15 +18,17 @@ public class OrderSummary(FinanceDbContext dbContext) : ICompositionRequestsHand
         var orderData = await request.Bind<OrderData>();
         var ct = request.HttpContext.RequestAborted;
 
-        var order = await dbContext.Orders
-            .Include(o => o.Items)
-            .SingleAsync(s => s.OrderId == orderData.OrderId, ct);
-
         // The email summary fires on OrderShipped, so by this point a
         // delivery option has been chosen; the .Value access matches the
         // pre-SQLite assumption that this is non-null on a placed order.
-        var deliveryOption = await dbContext.DeliveryOptions
-            .SingleAsync(s => s.DeliveryOptionId == order.DeliveryOptionId!.Value, ct);
+        var row = await (
+            from o in dbContext.Orders.Include(o => o.Items)
+            join d in dbContext.DeliveryOptions on o.DeliveryOptionId equals d.DeliveryOptionId
+            where o.OrderId == orderData.OrderId
+            select new { Order = o, DeliveryOption = d }).SingleAsync(ct);
+
+        var order = row.Order;
+        var deliveryOption = row.DeliveryOption;
 
         dynamic deliveryOptionModel = new ExpandoObject();
         deliveryOptionModel.Price = deliveryOption.Price;

--- a/src/PaymentInfo.Endpoint/Handlers/OrderAcceptedHandler.cs
+++ b/src/PaymentInfo.Endpoint/Handlers/OrderAcceptedHandler.cs
@@ -12,10 +12,11 @@ public class OrderAcceptedHandler(PaymentInfoDbContext dbContext) : IHandleMessa
 
     public async Task Handle(OrderAccepted message, IMessageHandlerContext context)
     {
-        var order = await dbContext.Orders
-            .SingleAsync(s => s.OrderId == message.OrderId, context.CancellationToken);
-        var creditCard = await dbContext.CreditCards
-            .SingleAsync(s => s.CreditCardId == order.CreditCardId, context.CancellationToken);
+        _ = await (
+            from o in dbContext.Orders
+            join c in dbContext.CreditCards on o.CreditCardId equals c.CreditCardId
+            where o.OrderId == message.OrderId
+            select new { o, c }).SingleAsync(context.CancellationToken);
 
         // Send a message to IT/Ops to talk to payment gateway and subtract money.
         // For now we'll assume it all worked and we'll move on.

--- a/src/PaymentInfo.Endpoint/Handlers/OrderAcceptedHandler.cs
+++ b/src/PaymentInfo.Endpoint/Handlers/OrderAcceptedHandler.cs
@@ -1,23 +1,15 @@
 using Catalog.Endpoint.Messages.Events;
-using Microsoft.EntityFrameworkCore;
 using NServiceBus.Logging;
-using PaymentInfo.Data;
 using PaymentInfo.Endpoint.Messages.Events;
 
 namespace PaymentInfo.Endpoint.Handlers;
 
-public class OrderAcceptedHandler(PaymentInfoDbContext dbContext) : IHandleMessages<OrderAccepted>
+public class OrderAcceptedHandler : IHandleMessages<OrderAccepted>
 {
     static ILog log = LogManager.GetLogger<OrderAcceptedHandler>();
 
     public async Task Handle(OrderAccepted message, IMessageHandlerContext context)
     {
-        _ = await (
-            from o in dbContext.Orders
-            join c in dbContext.CreditCards on o.CreditCardId equals c.CreditCardId
-            where o.OrderId == message.OrderId
-            select new { o, c }).SingleAsync(context.CancellationToken);
-
         // Send a message to IT/Ops to talk to payment gateway and subtract money.
         // For now we'll assume it all worked and we'll move on.
 

--- a/src/PaymentInfo.ServiceComposition/Checkout/SummaryHandler.cs
+++ b/src/PaymentInfo.ServiceComposition/Checkout/SummaryHandler.cs
@@ -17,15 +17,25 @@ public class SummaryHandler(PaymentInfoDbContext dbContext, CacheHelper cacheHel
         var orderId = Guid.Parse(orderIdString);
         var ct = request.HttpContext.RequestAborted;
 
-        var order = await dbContext.Orders
-            .FirstOrDefaultAsync(s => s.OrderId == orderId, ct);
-        if (order == null)
-        {
-            order = await cacheHelper.GetOrder(orderId);
-        }
+        var row = await (
+            from o in dbContext.Orders
+            where o.OrderId == orderId
+            from c in dbContext.CreditCards.Where(c => c.CreditCardId == o.CreditCardId).DefaultIfEmpty()
+            select new { Order = o, CreditCard = c })
+            .FirstOrDefaultAsync(ct);
 
-        var creditCard = await dbContext.CreditCards
-            .FirstOrDefaultAsync(s => s.CreditCardId == order.CreditCardId, ct);
+        Data.Models.CreditCard? creditCard;
+        if (row != null)
+        {
+            creditCard = row.CreditCard;
+        }
+        else
+        {
+            // Order not yet persisted; fall back to the in-progress cache.
+            var order = await cacheHelper.GetOrder(orderId);
+            creditCard = await dbContext.CreditCards
+                .FirstOrDefaultAsync(s => s.CreditCardId == order.CreditCardId, ct);
+        }
 
         var vm = request.GetComposedResponseModel();
         vm.CreditCardLastDigits = creditCard?.LastDigits;


### PR DESCRIPTION
## Summary
- Replaced paired or per-item SQLite lookups (left over from the LiteDB-era document model) with single JOIN/batched queries across Catalog, Finance, and PaymentInfo handlers.
- Removed an N+1 product lookup in `Finance.SubmitOrderItemsHandler` and a dead Order/CreditCard lookup in `PaymentInfo.OrderAcceptedHandler`.
- `PaymentInfo.SummaryHandler` uses a LEFT JOIN so the cache fallback path (order not yet persisted) is preserved.

## Test plan
- [x] `dotnet build src/OmNomNom.sln` (verified locally, 0 errors)
- [x] Run end-to-end checkout: place an order, verify email summary renders products, delivery option, and totals
- [x] Verify `/buy/summary/{orderId}` works both before order persistence (cache path) and after (DB path)
- [x] Verify `/product/{productId}` still returns product + inventory