### PR TITLE
Persist cart-page quantity edits and removals

### DIFF
--- a/src/Catalog.ServiceComposition/Checkout/OrderSubmitHandler.cs
+++ b/src/Catalog.ServiceComposition/Checkout/OrderSubmitHandler.cs
@@ -1,8 +1,12 @@
-﻿using Catalog.Endpoint.Messages.Commands;
+﻿using System.Text;
+using System.Text.Json;
+using Catalog.Data.Models;
+using Catalog.Endpoint.Messages.Commands;
 using Catalog.ServiceComposition.Helpers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using ServiceComposer.AspNetCore;
+using OrderItem = Catalog.Endpoint.Messages.Commands.OrderItem;
 
 namespace Catalog.ServiceComposition.Checkout;
 
@@ -12,13 +16,34 @@ public class OrderSubmitHandler(IMessageSession messageSession, CacheHelper cach
     public async Task Handle(HttpRequest request)
     {
         var data = await request.Bind<ShoppingCart>();
-        var order = await cacheHelper.GetOrder(data.OrderId);
-        
-        var message = new SubmitOrderItems();
-        message.OrderId = data.OrderId;
-        foreach (var item in order.Products)
+
+        // Read the cart items straight from the body. The shared cache only
+        // tracks Add-to-Cart calls; quantity edits made on the cart page
+        // arrive for the first time in this POST.
+        request.Body.Position = 0;
+        using var reader = new StreamReader(request.Body, Encoding.UTF8, leaveOpen: true);
+        var body = await reader.ReadToEndAsync();
+        var items = JsonSerializer.Deserialize<List<ShoppingCartItem>>(body,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
+
+        // Refresh the shared cache so a later GET /cart/{orderId} reflects
+        // what was actually submitted.
+        var cacheOrder = new Order { OrderId = data.OrderId };
+        foreach (var item in items)
         {
-            message.Items.Add(new OrderItem() { ProductId = item.ProductId, Quantity = item.Quantity });
+            cacheOrder.Products.Add(new Data.Models.OrderItem
+            {
+                OrderId = data.OrderId,
+                ProductId = item.ProductId,
+                Quantity = item.Quantity
+            });
+        }
+        await cacheHelper.StoreOrder(cacheOrder);
+
+        var message = new SubmitOrderItems { OrderId = data.OrderId };
+        foreach (var item in items)
+        {
+            message.Items.Add(new OrderItem { ProductId = item.ProductId, Quantity = item.Quantity });
         }
 
         await messageSession.Send(message);
@@ -27,5 +52,11 @@ public class OrderSubmitHandler(IMessageSession messageSession, CacheHelper cach
     class ShoppingCart
     {
         [FromRoute] public Guid OrderId { get; set; }
+    }
+
+    class ShoppingCartItem
+    {
+        public Guid ProductId { get; set; }
+        public int Quantity { get; set; }
     }
 }

--- a/src/website/src/routes/cart/[orderId]/+page.svelte
+++ b/src/website/src/routes/cart/[orderId]/+page.svelte
@@ -28,15 +28,32 @@
 
   onMount(load);
 
-  function changeQuantity(productId, newQuantity) {
+  async function changeQuantity(productId, newQuantity) {
     if (newQuantity <= 0) return removeItem(productId);
+    const current = items.find((it) => it.productId === productId)?.quantity ?? 0;
+    const delta = newQuantity - current;
+    if (delta === 0) return;
     items = items.map((it) =>
       it.productId === productId ? { ...it, quantity: newQuantity } : it
     );
+    try {
+      await gateway.addProductToCart(routeOrderId, { id: productId, quantity: delta });
+      await refreshCartCount(routeOrderId);
+    } catch {
+      await load();
+    }
   }
 
-  function removeItem(productId) {
+  async function removeItem(productId) {
+    const current = items.find((it) => it.productId === productId)?.quantity ?? 0;
     items = items.filter((it) => it.productId !== productId);
+    if (current <= 0) return;
+    try {
+      await gateway.addProductToCart(routeOrderId, { id: productId, quantity: -current });
+      await refreshCartCount(routeOrderId);
+    } catch {
+      await load();
+    }
   }
 
   async function saveAndContinue() {


### PR DESCRIPTION
## Summary
- Catalog's `OrderSubmitHandler` now reads cart items from the POST body (mirroring Finance) and refreshes the shared cache from them, so quantities edited on the cart page actually reach the Catalog database.
- The cart page's `+`/`-` and Remove handlers now sync deltas to the existing `/cart/addproduct/{orderId}` endpoint instead of mutating local Svelte state only — re-adding the same beer from the detail page no longer upserts onto a stale line.

## Test plan
- [x] Add beer A (qty 1), then on the cart page click `+` twice → both `Catalog.OrderItems` and `Finance.OrderItems` show A with `Quantity = 3` after Proceed → checkout flow.
- [x] Add beer A (qty 3), Remove it from the cart page, then add it again from `/product/A` → cart shows qty 1, not qty 4.
- [x] Decrease A from 5 to 2 with `-` on the cart page, then add 1 more from `/product/A` → cart shows qty 3, not qty 6.
- [x] After Proceed, navigate back to `/cart/{orderId}` → quantities reflect what was submitted.