### PR TITLE
Fix empty credit cards on payment page after shipping submit

### DIFF
--- a/src/Shipping.ServiceComposition/Checkout/SummaryHandler.cs
+++ b/src/Shipping.ServiceComposition/Checkout/SummaryHandler.cs
@@ -6,10 +6,11 @@ using Microsoft.EntityFrameworkCore;
 using ServiceComposer.AspNetCore;
 using Shipping.Data;
 using Shipping.ServiceComposition.Events;
+using Shipping.ServiceComposition.Helpers;
 
 namespace Shipping.ServiceComposition.Checkout;
 
-public class SummaryHandler(ShippingDbContext dbContext) : ICompositionRequestsHandler
+public class SummaryHandler(ShippingDbContext dbContext, CacheHelper cacheHelper) : ICompositionRequestsHandler
 {
     [HttpGet("/buy/payment/{orderId}")]
     [HttpGet("/buy/summary/{orderId}")]
@@ -21,19 +22,24 @@ public class SummaryHandler(ShippingDbContext dbContext) : ICompositionRequestsH
         var orderId = Guid.Parse(orderIdString);
         var ct = request.HttpContext.RequestAborted;
 
-        // The shipping POST that brought the customer here only sends a
-        // SubmitDeliveryOption command; the saga that writes the row runs
-        // asynchronously, so the Order may not yet exist (or may exist with
-        // a null DeliveryOptionId). Skip the delivery section in that case
-        // and let the rest of the composed response — credit cards, cart
-        // summary, etc. — render normally. A later refresh will pick the
-        // row up.
-        var order = await dbContext.Orders
-            .FirstOrDefaultAsync(s => s.OrderId == orderId, ct);
-        if (order?.DeliveryOptionId is not { } deliveryOptionId) return;
+        // DeliveryOptionSubmitHandler writes the chosen DeliveryOptionId to
+        // the cache synchronously, before sending the saga command, so the
+        // cache is the freshest source while the saga is still in flight.
+        // Fall back to the DB on a cache miss (sliding 30-min expiry); if
+        // both are empty, skip the delivery section so the rest of the
+        // composed response — credit cards, cart summary — still renders.
+        var cached = await cacheHelper.GetOrder(orderId);
+        Guid? deliveryOptionId = cached.DeliveryOptionId;
+        if (deliveryOptionId is null)
+        {
+            var order = await dbContext.Orders
+                .FirstOrDefaultAsync(s => s.OrderId == orderId, ct);
+            deliveryOptionId = order?.DeliveryOptionId;
+        }
+        if (deliveryOptionId is not { } resolvedId) return;
 
         var deliveryOption = await dbContext.DeliveryOptions
-            .SingleAsync(s => s.DeliveryOptionId == deliveryOptionId, ct);
+            .SingleAsync(s => s.DeliveryOptionId == resolvedId, ct);
 
         dynamic delivery = new ExpandoObject();
         delivery.DeliveryOptionName = deliveryOption.Name;

--- a/src/Shipping.ServiceComposition/Checkout/SummaryHandler.cs
+++ b/src/Shipping.ServiceComposition/Checkout/SummaryHandler.cs
@@ -21,12 +21,19 @@ public class SummaryHandler(ShippingDbContext dbContext) : ICompositionRequestsH
         var orderId = Guid.Parse(orderIdString);
         var ct = request.HttpContext.RequestAborted;
 
-        var order = await dbContext.Orders.SingleAsync(s => s.OrderId == orderId, ct);
-        // The customer reaches /buy/payment after picking shipping, so
-        // DeliveryOptionId should be set; .Value matches the pre-SQLite
-        // assumption that this row is non-null at this point.
+        // The shipping POST that brought the customer here only sends a
+        // SubmitDeliveryOption command; the saga that writes the row runs
+        // asynchronously, so the Order may not yet exist (or may exist with
+        // a null DeliveryOptionId). Skip the delivery section in that case
+        // and let the rest of the composed response — credit cards, cart
+        // summary, etc. — render normally. A later refresh will pick the
+        // row up.
+        var order = await dbContext.Orders
+            .FirstOrDefaultAsync(s => s.OrderId == orderId, ct);
+        if (order?.DeliveryOptionId is not { } deliveryOptionId) return;
+
         var deliveryOption = await dbContext.DeliveryOptions
-            .SingleAsync(s => s.DeliveryOptionId == order.DeliveryOptionId!.Value, ct);
+            .SingleAsync(s => s.DeliveryOptionId == deliveryOptionId, ct);
 
         dynamic delivery = new ExpandoObject();
         delivery.DeliveryOptionName = deliveryOption.Name;


### PR DESCRIPTION
## Summary
- Picking shipping fires a `SubmitDeliveryOption` NServiceBus command and immediately navigates to `/buy/payment/{orderId}`. The Shipping `SummaryHandler` reads the order row that the saga writes asynchronously, so on a fast hop it threw `Sequence contains no elements` and 500'd the whole composed response — `Promise.all` on the frontend then dropped the parallel credit-cards result, leaving an empty list until a back/forward gave the saga time to catch up.
- `DeliveryOptionSubmitHandler` already writes the chosen `DeliveryOptionId` to the Shipping cache *synchronously* before sending the command, so the cache is always at least as fresh as the eventual DB row. The summary handler now reads the option id from the cache first and falls back to the DB on cache miss; if neither has it, it skips the delivery section instead of throwing so the rest of the response (cards, cart summary, totals) still renders.

## Test plan
- [ ] Add a beer, walk through address → shipping → **Continue to Payment**. On the *first* visit the credit cards render and the Order Summary shows the chosen Shipping price (not $0).
- [ ] Refresh the payment page → still correct (cache hit).
- [ ] Wait long enough for the saga to land, refresh → still correct (DB fallback works).
- [ ] Visit `/buy/summary/{orderId}` after Place Order → delivery line still resolves correctly.