### PR TITLE
🐛 Preserve homepage filter after add-to-cart

### DIFF
--- a/src/website/src/routes/+page.svelte
+++ b/src/website/src/routes/+page.svelte
@@ -35,6 +35,11 @@
   let totalCount = $state(0);
   let totalPages = $state(0);
 
+  // Mirror the current URL query into product card hrefs so the
+  // detail page can navigate back to the same filtered view after
+  // "Add to Cart" instead of dropping the user on a bare "/".
+  let currentSearch = $derived(pageStore.url.search);
+
   const sortOptions = [
     { value: 'default', label: 'Default' },
     { value: 'rating', label: 'Top rated' },
@@ -191,7 +196,12 @@
   {:else}
     <div class="beer-grid">
       {#each products as product (product.productId)}
-        <a class="beer-card" href="/product/{product.productId}">
+        <a
+          class="beer-card"
+          href={currentSearch
+            ? `/product/${product.productId}?return=${encodeURIComponent(currentSearch)}`
+            : `/product/${product.productId}`}
+        >
           <BeerImage
             name={product.name}
             imageUrl={product.imageUrl}

--- a/src/website/src/routes/product/[productId]/+page.svelte
+++ b/src/website/src/routes/product/[productId]/+page.svelte
@@ -45,7 +45,8 @@
       });
       if (result?.orderId) orderId.set(result.orderId);
       await refreshCartCount(get(orderId));
-      await goto('/');
+      const returnSearch = page.url.searchParams.get('return');
+      await goto(returnSearch ? `/${returnSearch}` : '/');
     } finally {
       adding = false;
     }


### PR DESCRIPTION
## Summary
- The product detail page hard-coded `goto('/')` after add-to-cart, dropping the URL-mirrored filter/sort/page state the homepage relies on.
- Beer cards on the homepage now embed the current querystring as `?return=<encoded>` so the product page can navigate back to the same filtered view.
- Falls back to a bare `/` when no `return` param is present (e.g. deep-linking straight to a product).

## Test plan
- [ ] On `/`, apply a category/brewery/country/sort filter and verify the URL updates.
- [ ] Click a beer card and confirm the product URL contains a `return` query param.
- [ ] Click "Add to Cart" and confirm the homepage reopens with the original filters applied.
- [ ] Open a product page directly (no `return` param) and verify add-to-cart still returns to `/`.