### PR TITLE
Rename ICompositionRequestsHandler impls to *Composer

### DIFF
--- a/src/Catalog.ServiceComposition/Checkout/CartSummaryComposer.cs
+++ b/src/Catalog.ServiceComposition/Checkout/CartSummaryComposer.cs
@@ -17,8 +17,8 @@ namespace Catalog.ServiceComposition.Checkout;
 //
 // Shipping is intentionally excluded: that screen renders the full
 // `CartItemList` and still needs name/imageUrl, so it stays on the
-// existing `ShoppingCartHandler` path.
-public class CartSummaryHandler(CacheHelper cacheHelper) : ICompositionRequestsHandler
+// existing `ShoppingCartComposer` path.
+public class CartSummaryComposer(CacheHelper cacheHelper) : ICompositionRequestsHandler
 {
     [HttpGet("/buy/address/{orderId}")]
     [HttpGet("/buy/payment/{orderId}")]

--- a/src/Catalog.ServiceComposition/Checkout/OrderSubmitComposer.cs
+++ b/src/Catalog.ServiceComposition/Checkout/OrderSubmitComposer.cs
@@ -10,7 +10,7 @@ using OrderItem = Catalog.Endpoint.Messages.Commands.OrderItem;
 
 namespace Catalog.ServiceComposition.Checkout;
 
-public class OrderSubmitHandler(IMessageSession messageSession, CacheHelper cacheHelper) : ICompositionRequestsHandler
+public class OrderSubmitComposer(IMessageSession messageSession, CacheHelper cacheHelper) : ICompositionRequestsHandler
 {
     [HttpPost("/cart/{orderId}")]
     public async Task Handle(HttpRequest request)

--- a/src/Catalog.ServiceComposition/Checkout/ShoppingCartComposer.cs
+++ b/src/Catalog.ServiceComposition/Checkout/ShoppingCartComposer.cs
@@ -1,6 +1,4 @@
-using System.Dynamic;
 using Catalog.Data;
-using Catalog.Data.Models;
 using Catalog.ServiceComposition.Events;
 using Catalog.ServiceComposition.Helpers;
 using Microsoft.AspNetCore.Http;
@@ -11,9 +9,16 @@ using ServiceComposer.AspNetCore;
 
 namespace Catalog.ServiceComposition.Checkout;
 
-public class SummaryHandler(CatalogDbContext dbContext, CacheHelper cacheHelper) : ICompositionRequestsHandler
+// Powers the shipping screen, which renders the full `CartItemList`
+// (product image + name) on top of the order summary. Reads from the
+// SQLite Orders row first; if the SubmitOrderItems message hasn't been
+// processed yet, falls back to the in-flight cart in the distributed
+// cache so the page renders cleanly while the read model catches up.
+//
+// Address and payment use the leaner `CartSummaryComposer` instead.
+public class ShoppingCartComposer(CatalogDbContext dbContext, CacheHelper cacheHelper) : ICompositionRequestsHandler
 {
-    [HttpGet("/buy/summary/{orderId}")]
+    [HttpGet("/buy/shipping/{orderId}")]
     public async Task Handle(HttpRequest request)
     {
         var orderIdString = (string)request.HttpContext.GetRouteData().Values["orderId"]!;
@@ -29,33 +34,17 @@ public class SummaryHandler(CatalogDbContext dbContext, CacheHelper cacheHelper)
             order = await cacheHelper.GetOrder(orderId);
         }
 
-        var productsModel = MapToDictionary(order.Products);
+        var products = await dbContext.Products.ToListAsync(ct);
+        var orderedProducts = ShoppingCart.Mapper.MapToDictionary(order, products);
 
         var context = request.GetCompositionContext();
-        await context.RaiseEvent(new SummaryLoaded
+        await context.RaiseEvent(new CartLoaded
         {
-            OrderId = orderId,
-            Products = productsModel
+            OrderedProducts = orderedProducts
         });
 
         var vm = request.GetComposedResponseModel();
         vm.OrderId = orderId;
-        vm.Products = productsModel;
-    }
-
-    IDictionary<Guid, dynamic> MapToDictionary(List<OrderItem> products)
-    {
-        var productsViewModel = new Dictionary<Guid, dynamic>();
-
-        foreach (var product in products)
-        {
-            dynamic vm = new ExpandoObject();
-            vm.ProductId = product.ProductId;
-            vm.Quantity = product.Quantity;
-
-            productsViewModel[product.ProductId] = vm;
-        }
-
-        return productsViewModel;
+        vm.CartItems = orderedProducts.Values.ToList();
     }
 }

--- a/src/Catalog.ServiceComposition/Checkout/SummaryComposer.cs
+++ b/src/Catalog.ServiceComposition/Checkout/SummaryComposer.cs
@@ -1,4 +1,6 @@
+using System.Dynamic;
 using Catalog.Data;
+using Catalog.Data.Models;
 using Catalog.ServiceComposition.Events;
 using Catalog.ServiceComposition.Helpers;
 using Microsoft.AspNetCore.Http;
@@ -9,16 +11,9 @@ using ServiceComposer.AspNetCore;
 
 namespace Catalog.ServiceComposition.Checkout;
 
-// Powers the shipping screen, which renders the full `CartItemList`
-// (product image + name) on top of the order summary. Reads from the
-// SQLite Orders row first; if the SubmitOrderItems message hasn't been
-// processed yet, falls back to the in-flight cart in the distributed
-// cache so the page renders cleanly while the read model catches up.
-//
-// Address and payment use the leaner `CartSummaryHandler` instead.
-public class ShoppingCartHandler(CatalogDbContext dbContext, CacheHelper cacheHelper) : ICompositionRequestsHandler
+public class SummaryComposer(CatalogDbContext dbContext, CacheHelper cacheHelper) : ICompositionRequestsHandler
 {
-    [HttpGet("/buy/shipping/{orderId}")]
+    [HttpGet("/buy/summary/{orderId}")]
     public async Task Handle(HttpRequest request)
     {
         var orderIdString = (string)request.HttpContext.GetRouteData().Values["orderId"]!;
@@ -34,17 +29,33 @@ public class ShoppingCartHandler(CatalogDbContext dbContext, CacheHelper cacheHe
             order = await cacheHelper.GetOrder(orderId);
         }
 
-        var products = await dbContext.Products.ToListAsync(ct);
-        var orderedProducts = ShoppingCart.Mapper.MapToDictionary(order, products);
+        var productsModel = MapToDictionary(order.Products);
 
         var context = request.GetCompositionContext();
-        await context.RaiseEvent(new CartLoaded
+        await context.RaiseEvent(new SummaryLoaded
         {
-            OrderedProducts = orderedProducts
+            OrderId = orderId,
+            Products = productsModel
         });
 
         var vm = request.GetComposedResponseModel();
         vm.OrderId = orderId;
-        vm.CartItems = orderedProducts.Values.ToList();
+        vm.Products = productsModel;
+    }
+
+    IDictionary<Guid, dynamic> MapToDictionary(List<OrderItem> products)
+    {
+        var productsViewModel = new Dictionary<Guid, dynamic>();
+
+        foreach (var product in products)
+        {
+            dynamic vm = new ExpandoObject();
+            vm.ProductId = product.ProductId;
+            vm.Quantity = product.Quantity;
+
+            productsViewModel[product.ProductId] = vm;
+        }
+
+        return productsViewModel;
     }
 }

--- a/src/Catalog.ServiceComposition/Checkout/SummarySubmitComposer.cs
+++ b/src/Catalog.ServiceComposition/Checkout/SummarySubmitComposer.cs
@@ -6,7 +6,7 @@ using ServiceComposer.AspNetCore;
 
 namespace Catalog.ServiceComposition.Checkout;
 
-public class SummarySubmitHandler(IMessageSession messageSession) : ICompositionRequestsHandler
+public class SummarySubmitComposer(IMessageSession messageSession) : ICompositionRequestsHandler
 {
     [HttpPost("/buy/summary/{orderId}")]
     public async Task Handle(HttpRequest request)

--- a/src/Catalog.ServiceComposition/Email/OrderSummaryComposer.cs
+++ b/src/Catalog.ServiceComposition/Email/OrderSummaryComposer.cs
@@ -9,7 +9,7 @@ using ServiceComposer.AspNetCore;
 
 namespace Catalog.ServiceComposition.Email;
 
-public class OrderSummary(CatalogDbContext dbContext) : ICompositionRequestsHandler
+public class OrderSummaryComposer(CatalogDbContext dbContext) : ICompositionRequestsHandler
 {
     [HttpGet("/email/summary/{orderId}")]
     public async Task Handle(HttpRequest request)

--- a/src/Catalog.ServiceComposition/Products/ProductComposer.cs
+++ b/src/Catalog.ServiceComposition/Products/ProductComposer.cs
@@ -8,7 +8,7 @@ using ServiceComposer.AspNetCore;
 
 namespace Catalog.ServiceComposition.Products;
 
-public class ProductHandler(CatalogDbContext dbContext) : ICompositionRequestsHandler
+public class ProductComposer(CatalogDbContext dbContext) : ICompositionRequestsHandler
 {
     [HttpGet("/product/{productId}")]
     public async Task Handle(HttpRequest request)

--- a/src/Catalog.ServiceComposition/Products/ProductsComposer.cs
+++ b/src/Catalog.ServiceComposition/Products/ProductsComposer.cs
@@ -28,7 +28,7 @@ namespace Catalog.ServiceComposition.Products;
 // The composed response carries:
 //   Products    list of dictionary values for the page (in order)
 //   Page, PageSize, TotalCount, TotalPages
-public class ProductsHandler(CatalogDbContext dbContext) : ICompositionRequestsHandler
+public class ProductsComposer(CatalogDbContext dbContext) : ICompositionRequestsHandler
 {
     const int DefaultPageSize = 12;
     const int MaxPageSize = 50;

--- a/src/Catalog.ServiceComposition/Products/ProductsFacetsComposer.cs
+++ b/src/Catalog.ServiceComposition/Products/ProductsFacetsComposer.cs
@@ -9,12 +9,12 @@ namespace Catalog.ServiceComposition.Products;
 
 // Returns the distinct values for each filter axis the dropdowns
 // need to populate. Restricted to in-stock products to match the
-// default ProductsHandler filter - otherwise the UI would offer
+// default ProductsComposer filter - otherwise the UI would offer
 // breweries/countries whose only beers are sold out, leading to a
 // "No beers match your filter" page after the user picks one.
 //
 // Three small distinct queries; cheap enough to compute on every call.
-public class ProductsFacetsHandler(CatalogDbContext dbContext) : ICompositionRequestsHandler
+public class ProductsFacetsComposer(CatalogDbContext dbContext) : ICompositionRequestsHandler
 {
     [HttpGet("/products/facets")]
     public async Task Handle(HttpRequest request)

--- a/src/Catalog.ServiceComposition/ShoppingCart/ShoppingCartAddItemComposer.cs
+++ b/src/Catalog.ServiceComposition/ShoppingCart/ShoppingCartAddItemComposer.cs
@@ -6,7 +6,7 @@ using ServiceComposer.AspNetCore;
 
 namespace Catalog.ServiceComposition.ShoppingCart;
 
-public class ShoppingCartAddItemHandler(CacheHelper cacheHelper) : ICompositionRequestsHandler
+public class ShoppingCartAddItemComposer(CacheHelper cacheHelper) : ICompositionRequestsHandler
 {
     [HttpPost("/cart/addproduct/{orderId}")]
     public async Task Handle(HttpRequest request)

--- a/src/Catalog.ServiceComposition/ShoppingCart/ShoppingCartComposer.cs
+++ b/src/Catalog.ServiceComposition/ShoppingCart/ShoppingCartComposer.cs
@@ -9,7 +9,7 @@ using ServiceComposer.AspNetCore;
 
 namespace Catalog.ServiceComposition.ShoppingCart;
 
-public class ShoppingCartHandler(CacheHelper cacheHelper, CatalogDbContext dbContext) : ICompositionRequestsHandler
+public class ShoppingCartComposer(CacheHelper cacheHelper, CatalogDbContext dbContext) : ICompositionRequestsHandler
 {
     [HttpGet("/cart/{orderId}")]
     public async Task Handle(HttpRequest request)

--- a/src/Catalog.ServiceComposition/ShoppingCart/ShoppingCartExistsComposer.cs
+++ b/src/Catalog.ServiceComposition/ShoppingCart/ShoppingCartExistsComposer.cs
@@ -7,7 +7,7 @@ using ServiceComposer.AspNetCore;
 
 namespace Catalog.ServiceComposition.ShoppingCart;
 
-public class ShoppingCartExistsHandler(CacheHelper cacheHelper, CatalogDbContext dbContext): ICompositionRequestsHandler
+public class ShoppingCartExistsComposer(CacheHelper cacheHelper, CatalogDbContext dbContext): ICompositionRequestsHandler
 {
     [HttpGet("/existingCart/{orderId}")]
     public async Task Handle(HttpRequest request)

--- a/src/Finance.ServiceComposition/Checkout/AddressComposer.cs
+++ b/src/Finance.ServiceComposition/Checkout/AddressComposer.cs
@@ -1,14 +1,14 @@
+using Finance.Data;
+using Finance.Data.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using ServiceComposer.AspNetCore;
-using Shipping.Data;
-using Shipping.Data.Models;
 
-namespace Shipping.ServiceComposition.Checkout;
+namespace Finance.ServiceComposition.Checkout;
 
-public class AddressHandler(ShippingDbContext dbContext) : ICompositionRequestsHandler
+public class AddressComposer(FinanceDbContext dbContext) : ICompositionRequestsHandler
 {
     [HttpGet("/buy/address/{orderId}")]
     public async Task Handle(HttpRequest request)
@@ -22,12 +22,12 @@ public class AddressHandler(ShippingDbContext dbContext) : ICompositionRequestsH
 
         // If there is no order yet, we retrieve the address from the previous order.
         Address address;
-        if (order?.Address == null)
+        if (order?.BillingAddress == null)
             address = RetrieveAddressFromPreviousOrder(orderId);
         else
-            address = order.Address;
+            address = order.BillingAddress;
 
-        vm.ShippingAddress = address;
+        vm.BillingAddress = address;
     }
 
     Address RetrieveAddressFromPreviousOrder(Guid orderId)

--- a/src/Finance.ServiceComposition/Checkout/AddressSubmitComposer.cs
+++ b/src/Finance.ServiceComposition/Checkout/AddressSubmitComposer.cs
@@ -6,7 +6,7 @@ using ServiceComposer.AspNetCore;
 
 namespace Finance.ServiceComposition.Checkout;
 
-public class AddressSubmitHandler(IMessageSession messageSession) : ICompositionRequestsHandler
+public class AddressSubmitComposer(IMessageSession messageSession) : ICompositionRequestsHandler
 {
     [HttpPost("/buy/address/{orderId}")]
     public async Task Handle(HttpRequest request)

--- a/src/Finance.ServiceComposition/Checkout/DeliveryOptionSubmitComposer.cs
+++ b/src/Finance.ServiceComposition/Checkout/DeliveryOptionSubmitComposer.cs
@@ -1,22 +1,17 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Finance.Endpoint.Messages.Commands;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using ServiceComposer.AspNetCore;
-using Shipping.Endpoint.Messages.Commands;
-using Shipping.ServiceComposition.Helpers;
 
-namespace Shipping.ServiceComposition.Checkout;
+namespace Finance.ServiceComposition.Checkout;
 
-public class DeliveryOptionSubmitHandler(IMessageSession messageSession, CacheHelper cacheHelper) : ICompositionRequestsHandler
+public class DeliveryOptionSubmitComposer(IMessageSession messageSession) : ICompositionRequestsHandler
 {
     [HttpPost("/buy/shipping/{orderId}")]
     public async Task Handle(HttpRequest request)
     {
         var submitted = await request.Bind<SelectedDeliveryOption>();
 
-        var order = await cacheHelper.GetOrder(submitted.OrderId);
-        order.DeliveryOptionId = submitted.Body.DeliveryOptionId;
-        await cacheHelper.StoreOrder(order);
-        
         var message = new SubmitDeliveryOption()
         {
             OrderId = submitted.OrderId,

--- a/src/Finance.ServiceComposition/Checkout/OrderSubmitComposer.cs
+++ b/src/Finance.ServiceComposition/Checkout/OrderSubmitComposer.cs
@@ -11,7 +11,7 @@ using OrderItem = Finance.Endpoint.Messages.Commands.OrderItem;
 
 namespace Finance.ServiceComposition.Checkout;
 
-public class OrderSubmitHandler(IMessageSession messageSession, CacheHelper cacheHelper) : ICompositionRequestsHandler
+public class OrderSubmitComposer(IMessageSession messageSession, CacheHelper cacheHelper) : ICompositionRequestsHandler
 {
     [HttpPost("/cart/{orderId}")]
     public async Task Handle(HttpRequest request)

--- a/src/Finance.ServiceComposition/Email/OrderSummaryComposer.cs
+++ b/src/Finance.ServiceComposition/Email/OrderSummaryComposer.cs
@@ -10,7 +10,7 @@ using Shipping.ServiceComposition.Events;
 
 namespace Finance.ServiceComposition.Email;
 
-public class OrderSummary(FinanceDbContext dbContext) : ICompositionRequestsHandler
+public class OrderSummaryComposer(FinanceDbContext dbContext) : ICompositionRequestsHandler
 {
     [HttpGet("/email/summary/{orderId}")]
     public async Task Handle(HttpRequest request)

--- a/src/Finance.ServiceComposition/Orders/CartSummaryLoadedSubscriber.cs
+++ b/src/Finance.ServiceComposition/Orders/CartSummaryLoadedSubscriber.cs
@@ -7,7 +7,7 @@ using ServiceComposer.AspNetCore;
 
 namespace Finance.ServiceComposition.Orders;
 
-// Companion to `CartSummaryHandler` on the Catalog side: receives
+// Companion to `CartSummaryComposer` on the Catalog side: receives
 // `CartSummaryLoaded`, attaches per-item Price/Discount from Finance's
 // Products view, and exposes the cart total. The shipping route uses
 // the heavier `CartLoadedSubscriber`/`CartLoaded` pair instead, because

--- a/src/PaymentInfo.ServiceComposition/Checkout/CreditCardComposer.cs
+++ b/src/PaymentInfo.ServiceComposition/Checkout/CreditCardComposer.cs
@@ -7,7 +7,7 @@ using ServiceComposer.AspNetCore;
 
 namespace PaymentInfo.ServiceComposition.Checkout;
 
-public class CreditCard(PaymentInfoDbContext dbContext) : ICompositionRequestsHandler
+public class CreditCardComposer(PaymentInfoDbContext dbContext) : ICompositionRequestsHandler
 {
     [HttpGet("/buy/creditcard/{customerId}")]
     public async Task Handle(HttpRequest request)

--- a/src/PaymentInfo.ServiceComposition/Checkout/PaymentComposer.cs
+++ b/src/PaymentInfo.ServiceComposition/Checkout/PaymentComposer.cs
@@ -7,7 +7,7 @@ using ServiceComposer.AspNetCore;
 
 namespace PaymentInfo.ServiceComposition.Checkout;
 
-public class PaymentHandler(PaymentInfoDbContext dbContext) : ICompositionRequestsHandler
+public class PaymentComposer(PaymentInfoDbContext dbContext) : ICompositionRequestsHandler
 {
     [HttpGet("/buy/payment/{orderId}")]
     public async Task Handle(HttpRequest request)

--- a/src/PaymentInfo.ServiceComposition/Checkout/PaymentSubmitComposer.cs
+++ b/src/PaymentInfo.ServiceComposition/Checkout/PaymentSubmitComposer.cs
@@ -7,7 +7,7 @@ using ServiceComposer.AspNetCore;
 
 namespace PaymentInfo.ServiceComposition.Checkout;
 
-public class PaymentSubmitHandler(IMessageSession messageSession, CacheHelper cacheHelper) : ICompositionRequestsHandler
+public class PaymentSubmitComposer(IMessageSession messageSession, CacheHelper cacheHelper) : ICompositionRequestsHandler
 {
     [HttpPost("/buy/payment/{orderId}")]
     public async Task Handle(HttpRequest request)

--- a/src/PaymentInfo.ServiceComposition/Checkout/SummaryComposer.cs
+++ b/src/PaymentInfo.ServiceComposition/Checkout/SummaryComposer.cs
@@ -8,7 +8,7 @@ using ServiceComposer.AspNetCore;
 
 namespace PaymentInfo.ServiceComposition.Checkout;
 
-public class SummaryHandler(PaymentInfoDbContext dbContext, CacheHelper cacheHelper) : ICompositionRequestsHandler
+public class SummaryComposer(PaymentInfoDbContext dbContext, CacheHelper cacheHelper) : ICompositionRequestsHandler
 {
     [HttpGet("/buy/summary/{orderId}")]
     public async Task Handle(HttpRequest request)

--- a/src/Shipping.ServiceComposition/Checkout/AddressComposer.cs
+++ b/src/Shipping.ServiceComposition/Checkout/AddressComposer.cs
@@ -1,14 +1,14 @@
-using Finance.Data;
-using Finance.Data.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using ServiceComposer.AspNetCore;
+using Shipping.Data;
+using Shipping.Data.Models;
 
-namespace Finance.ServiceComposition.Checkout;
+namespace Shipping.ServiceComposition.Checkout;
 
-public class AddressHandler(FinanceDbContext dbContext) : ICompositionRequestsHandler
+public class AddressComposer(ShippingDbContext dbContext) : ICompositionRequestsHandler
 {
     [HttpGet("/buy/address/{orderId}")]
     public async Task Handle(HttpRequest request)
@@ -22,12 +22,12 @@ public class AddressHandler(FinanceDbContext dbContext) : ICompositionRequestsHa
 
         // If there is no order yet, we retrieve the address from the previous order.
         Address address;
-        if (order?.BillingAddress == null)
+        if (order?.Address == null)
             address = RetrieveAddressFromPreviousOrder(orderId);
         else
-            address = order.BillingAddress;
+            address = order.Address;
 
-        vm.BillingAddress = address;
+        vm.ShippingAddress = address;
     }
 
     Address RetrieveAddressFromPreviousOrder(Guid orderId)

--- a/src/Shipping.ServiceComposition/Checkout/AddressSubmitComposer.cs
+++ b/src/Shipping.ServiceComposition/Checkout/AddressSubmitComposer.cs
@@ -6,7 +6,7 @@ using Shipping.Endpoint.Messages.Commands;
 
 namespace Shipping.ServiceComposition.Checkout;
 
-public class AddressSubmitHandler(IMessageSession messageSession) : ICompositionRequestsHandler
+public class AddressSubmitComposer(IMessageSession messageSession) : ICompositionRequestsHandler
 {
     [HttpPost("/buy/address/{orderId}")]
     public async Task Handle(HttpRequest request)

--- a/src/Shipping.ServiceComposition/Checkout/DeliveryOptionSubmitComposer.cs
+++ b/src/Shipping.ServiceComposition/Checkout/DeliveryOptionSubmitComposer.cs
@@ -1,17 +1,22 @@
-﻿using Finance.Endpoint.Messages.Commands;
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using ServiceComposer.AspNetCore;
+using Shipping.Endpoint.Messages.Commands;
+using Shipping.ServiceComposition.Helpers;
 
-namespace Finance.ServiceComposition.Checkout;
+namespace Shipping.ServiceComposition.Checkout;
 
-public class DeliveryOptionSubmitHandler(IMessageSession messageSession) : ICompositionRequestsHandler
+public class DeliveryOptionSubmitComposer(IMessageSession messageSession, CacheHelper cacheHelper) : ICompositionRequestsHandler
 {
     [HttpPost("/buy/shipping/{orderId}")]
     public async Task Handle(HttpRequest request)
     {
         var submitted = await request.Bind<SelectedDeliveryOption>();
 
+        var order = await cacheHelper.GetOrder(submitted.OrderId);
+        order.DeliveryOptionId = submitted.Body.DeliveryOptionId;
+        await cacheHelper.StoreOrder(order);
+        
         var message = new SubmitDeliveryOption()
         {
             OrderId = submitted.OrderId,

--- a/src/Shipping.ServiceComposition/Checkout/DeliveryOptionsComposer.cs
+++ b/src/Shipping.ServiceComposition/Checkout/DeliveryOptionsComposer.cs
@@ -10,7 +10,7 @@ using Shipping.ServiceComposition.Helpers;
 
 namespace Shipping.ServiceComposition.Checkout;
 
-public class DeliveryOptionsHandler(ShippingDbContext dbContext, CacheHelper cacheHelper) : ICompositionRequestsHandler
+public class DeliveryOptionsComposer(ShippingDbContext dbContext, CacheHelper cacheHelper) : ICompositionRequestsHandler
 {
     [HttpGet("/buy/shipping/{orderId}")]
     public async Task Handle(HttpRequest request)

--- a/src/Shipping.ServiceComposition/Checkout/SummaryComposer.cs
+++ b/src/Shipping.ServiceComposition/Checkout/SummaryComposer.cs
@@ -10,7 +10,7 @@ using Shipping.ServiceComposition.Helpers;
 
 namespace Shipping.ServiceComposition.Checkout;
 
-public class SummaryHandler(ShippingDbContext dbContext, CacheHelper cacheHelper) : ICompositionRequestsHandler
+public class SummaryComposer(ShippingDbContext dbContext, CacheHelper cacheHelper) : ICompositionRequestsHandler
 {
     [HttpGet("/buy/payment/{orderId}")]
     [HttpGet("/buy/summary/{orderId}")]
@@ -22,7 +22,7 @@ public class SummaryHandler(ShippingDbContext dbContext, CacheHelper cacheHelper
         var orderId = Guid.Parse(orderIdString);
         var ct = request.HttpContext.RequestAborted;
 
-        // DeliveryOptionSubmitHandler writes the chosen DeliveryOptionId to
+        // DeliveryOptionSubmitComposer writes the chosen DeliveryOptionId to
         // the cache synchronously, before sending the saga command, so the
         // cache is the freshest source while the saga is still in flight.
         // Fall back to the DB on a cache miss (sliding 30-min expiry); if


### PR DESCRIPTION
## Summary

- Renames all 26 `ICompositionRequestsHandler` implementations under `src/*.ServiceComposition/` from `*Handler` to `*Composer`.
- Disambiguates ServiceComposer classes from NServiceBus `IHandleMessages<T>` impls, which keep the `Handler` suffix.
- Brings the three outliers (`Catalog.ServiceComposition/Email/OrderSummary.cs`, `Finance.ServiceComposition/Email/OrderSummary.cs`, `PaymentInfo.ServiceComposition/Checkout/CreditCard.cs`) in line with the convention.
- `ICompositionEventsSubscriber` impls keep the existing `*Subscriber` suffix.

Mechanical rename only — no behavior changes, no DI/registration changes (ServiceComposer auto-discovers handlers from all loaded assemblies).

Final convention:

| Suffix | Interface | World |
|---|---|---|
| `Composer` | `ICompositionRequestsHandler` | ServiceComposer (HTTP, in-process) |
| `Subscriber` | `ICompositionEventsSubscriber` | ServiceComposer (in-process events) |
| `Handler` | `IHandleMessages<T>` | NServiceBus (durable messages) |

## Test plan

- [x] `dotnet build src/OmNomNom.slnx -c Debug` — green (verified locally, 0 errors, no new warnings).
- [x] `grep -rn "class \w*Handler\b" src/*.ServiceComposition/ --include="*.cs"` returns nothing.
- [x] Run the gateway + a boundary endpoint, hit at least one GET `*Composer` route and one POST `*SubmitComposer` route; confirm same response/state as before.