### PR TITLE
Upgrade ServiceComposer to 5.2 and modernise composition handlers

### DIFF
--- a/src/Catalog.ServiceComposition/Catalog.ServiceComposition.csproj
+++ b/src/Catalog.ServiceComposition/Catalog.ServiceComposition.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
       <PackageReference Include="NServiceBus" Version="10.1.4" />
-      <PackageReference Include="ServiceComposer.AspNetCore" Version="2.1.0" />
+      <PackageReference Include="ServiceComposer.AspNetCore" Version="5.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Catalog.ServiceComposition/Checkout/CartSummaryComposer.cs
+++ b/src/Catalog.ServiceComposition/Checkout/CartSummaryComposer.cs
@@ -1,4 +1,3 @@
-using System.Dynamic;
 using Catalog.ServiceComposition.Events;
 using Catalog.ServiceComposition.Workflow;
 using Microsoft.AspNetCore.Http;
@@ -37,14 +36,7 @@ public class CartSummaryComposer(IWorkflowStore workflow, IHttpContextAccessor h
         var cart = await workflow.Read<CartSlice>(orderId, CartWorkflowSlice.Key, ct)
                    ?? CartSlice.Empty;
 
-        var orderedProducts = new Dictionary<Guid, dynamic>();
-        foreach (var line in cart.Items)
-        {
-            dynamic vm = new ExpandoObject();
-            vm.ProductId = line.ProductId;
-            vm.Quantity = line.Quantity;
-            orderedProducts[line.ProductId] = vm;
-        }
+        var orderedProducts = Mapper.MapToDictionary(cart);
 
         var context = request.GetCompositionContext();
         await context.RaiseEvent(new CartSummaryLoaded

--- a/src/Catalog.ServiceComposition/Checkout/CartSummaryComposer.cs
+++ b/src/Catalog.ServiceComposition/Checkout/CartSummaryComposer.cs
@@ -3,7 +3,6 @@ using Catalog.ServiceComposition.Events;
 using Catalog.ServiceComposition.Workflow;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
 using ServiceComposer.AspNetCore;
 using WorkflowComposer;
 
@@ -17,15 +16,22 @@ namespace Catalog.ServiceComposition.Checkout;
 //
 // Shipping is intentionally excluded: that screen renders the full
 // `CartItemList` and still needs name/imageUrl, so it stays on the
-// existing `ShoppingCartComposer` path.
-public class CartSummaryComposer(IWorkflowStore workflow) : ICompositionRequestsHandler
+// existing `ShippingScreenCartComposer` path.
+[CompositionHandler]
+public class CartSummaryComposer(IWorkflowStore workflow, IHttpContextAccessor http)
 {
+    // ServiceComposer 5.x allows only one Http* attribute per method,
+    // so the address and payment screens get their own entry points
+    // that both delegate to LoadAsync. The work is identical.
     [HttpGet("/buy/address/{orderId}")]
+    public Task HandleAddress(Guid orderId) => LoadAsync(orderId);
+
     [HttpGet("/buy/payment/{orderId}")]
-    public async Task Handle(HttpRequest request)
+    public Task HandlePayment(Guid orderId) => LoadAsync(orderId);
+
+    async Task LoadAsync(Guid orderId)
     {
-        var orderIdString = (string)request.HttpContext.GetRouteData().Values["orderId"]!;
-        var orderId = Guid.Parse(orderIdString);
+        var request = http.HttpContext!.Request;
         var ct = request.HttpContext.RequestAborted;
 
         var cart = await workflow.Read<CartSlice>(orderId, CartWorkflowSlice.Key, ct)

--- a/src/Catalog.ServiceComposition/Checkout/Mapper.cs
+++ b/src/Catalog.ServiceComposition/Checkout/Mapper.cs
@@ -1,0 +1,33 @@
+using System.Dynamic;
+using Catalog.ServiceComposition.Workflow;
+
+namespace Catalog.ServiceComposition.Checkout;
+
+// Lean cart-line viewmodel used by the address, payment, and summary
+// screens. Carries only ProductId + Quantity; Finance subscribers
+// attach Price/Discount via CartSummaryLoaded / SummaryLoaded events,
+// and Catalog subscribers attach Name/ImageUrl on /buy/summary.
+// The cart and shipping screens need a richer line (Name + ImageUrl)
+// and use the heavier Catalog.ShoppingCart.Mapper instead.
+public static class Mapper
+{
+    public static IDictionary<Guid, dynamic> MapToDictionary(CartSlice cart)
+    {
+        var productsViewModel = new Dictionary<Guid, dynamic>();
+
+        foreach (var line in cart.Items)
+        {
+            productsViewModel[line.ProductId] = MapToViewModel(line);
+        }
+
+        return productsViewModel;
+    }
+
+    public static dynamic MapToViewModel(CartLine line)
+    {
+        dynamic vm = new ExpandoObject();
+        vm.ProductId = line.ProductId;
+        vm.Quantity = line.Quantity;
+        return vm;
+    }
+}

--- a/src/Catalog.ServiceComposition/Checkout/OrderSubmitComposer.cs
+++ b/src/Catalog.ServiceComposition/Checkout/OrderSubmitComposer.cs
@@ -32,17 +32,11 @@ public class OrderSubmitComposer(IWorkflowStore workflow, IHttpContextAccessor h
         // also reads the body. ServiceComposer enables buffering, so rewind
         // before each read so whichever composer runs second still sees JSON.
         request.Body.Position = 0;
-        var items = await JsonSerializer.DeserializeAsync<List<ShoppingCartItem>>(request.Body, JsonOptions, ct) ?? [];
+        var items = await JsonSerializer.DeserializeAsync<List<CartItemForm>>(request.Body, JsonOptions, ct) ?? [];
 
         var slice = new CartSlice(items
             .Select(i => new CartLine(i.ProductId, i.Quantity))
             .ToList());
         await workflow.Write(orderId, CartWorkflowSlice.Key, slice, ct);
-    }
-
-    public class ShoppingCartItem
-    {
-        public Guid ProductId { get; set; }
-        public int Quantity { get; set; }
     }
 }

--- a/src/Catalog.ServiceComposition/Checkout/OrderSubmitComposer.cs
+++ b/src/Catalog.ServiceComposition/Checkout/OrderSubmitComposer.cs
@@ -28,6 +28,10 @@ public class OrderSubmitComposer(IWorkflowStore workflow, IHttpContextAccessor h
     {
         var request = http.HttpContext!.Request;
         var ct = request.HttpContext.RequestAborted;
+        // Finance has a matching OrderSubmitComposer on the same route that
+        // also reads the body. ServiceComposer enables buffering, so rewind
+        // before each read so whichever composer runs second still sees JSON.
+        request.Body.Position = 0;
         var items = await JsonSerializer.DeserializeAsync<List<ShoppingCartItem>>(request.Body, JsonOptions, ct) ?? [];
 
         var slice = new CartSlice(items

--- a/src/Catalog.ServiceComposition/Checkout/OrderSubmitComposer.cs
+++ b/src/Catalog.ServiceComposition/Checkout/OrderSubmitComposer.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using System.Text.Json;
 using Catalog.ServiceComposition.Workflow;
 using Microsoft.AspNetCore.Http;
@@ -13,32 +12,31 @@ namespace Catalog.ServiceComposition.Checkout;
 // edits arrive here for the first time). Updates the cart slice;
 // SubmitOrderItems will be dispatched later by SummarySubmitComposer
 // as part of the atomic checkout submit.
-public class OrderSubmitComposer(IWorkflowStore workflow) : ICompositionRequestsHandler
+//
+// The body is a raw JSON array of ShoppingCartItem. Read it directly
+// from request.Body instead of [FromBody] - ServiceComposer 5.2's
+// source generator can't currently encode generic parameter types
+// (List<T>, T[]) into hintNames, and we don't want to wrap the
+// frontend contract just to work around that.
+[CompositionHandler]
+public class OrderSubmitComposer(IWorkflowStore workflow, IHttpContextAccessor http)
 {
-    [HttpPost("/cart/{orderId}")]
-    public async Task Handle(HttpRequest request)
-    {
-        var data = await request.Bind<ShoppingCart>();
-        var ct = request.HttpContext.RequestAborted;
+    static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
-        request.Body.Position = 0;
-        using var reader = new StreamReader(request.Body, Encoding.UTF8, leaveOpen: true);
-        var body = await reader.ReadToEndAsync(ct);
-        var items = JsonSerializer.Deserialize<List<ShoppingCartItem>>(body,
-            new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
+    [HttpPost("/cart/{orderId}")]
+    public async Task Handle(Guid orderId)
+    {
+        var request = http.HttpContext!.Request;
+        var ct = request.HttpContext.RequestAborted;
+        var items = await JsonSerializer.DeserializeAsync<List<ShoppingCartItem>>(request.Body, JsonOptions, ct) ?? [];
 
         var slice = new CartSlice(items
             .Select(i => new CartLine(i.ProductId, i.Quantity))
             .ToList());
-        await workflow.Write(data.OrderId, CartWorkflowSlice.Key, slice, ct);
+        await workflow.Write(orderId, CartWorkflowSlice.Key, slice, ct);
     }
 
-    class ShoppingCart
-    {
-        [FromRoute] public Guid OrderId { get; set; }
-    }
-
-    class ShoppingCartItem
+    public class ShoppingCartItem
     {
         public Guid ProductId { get; set; }
         public int Quantity { get; set; }

--- a/src/Catalog.ServiceComposition/Checkout/ShippingScreenCartComposer.cs
+++ b/src/Catalog.ServiceComposition/Checkout/ShippingScreenCartComposer.cs
@@ -3,7 +3,6 @@ using Catalog.ServiceComposition.Events;
 using Catalog.ServiceComposition.Workflow;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using ServiceComposer.AspNetCore;
 using WorkflowComposer;
@@ -16,13 +15,13 @@ namespace Catalog.ServiceComposition.Checkout;
 // catalog domain DB.
 //
 // Address and payment use the leaner `CartSummaryComposer` instead.
-public class ShoppingCartComposer(IWorkflowStore workflow, CatalogDbContext dbContext) : ICompositionRequestsHandler
+[CompositionHandler]
+public class ShippingScreenCartComposer(IWorkflowStore workflow, CatalogDbContext dbContext, IHttpContextAccessor http)
 {
     [HttpGet("/buy/shipping/{orderId}")]
-    public async Task Handle(HttpRequest request)
+    public async Task Handle(Guid orderId)
     {
-        var orderIdString = (string)request.HttpContext.GetRouteData().Values["orderId"]!;
-        var orderId = Guid.Parse(orderIdString);
+        var request = http.HttpContext!.Request;
         var ct = request.HttpContext.RequestAborted;
 
         var cart = await workflow.Read<CartSlice>(orderId, CartWorkflowSlice.Key, ct)

--- a/src/Catalog.ServiceComposition/Checkout/SummaryComposer.cs
+++ b/src/Catalog.ServiceComposition/Checkout/SummaryComposer.cs
@@ -3,19 +3,18 @@ using Catalog.ServiceComposition.Events;
 using Catalog.ServiceComposition.Workflow;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
 using ServiceComposer.AspNetCore;
 using WorkflowComposer;
 
 namespace Catalog.ServiceComposition.Checkout;
 
-public class SummaryComposer(IWorkflowStore workflow) : ICompositionRequestsHandler
+[CompositionHandler]
+public class SummaryComposer(IWorkflowStore workflow, IHttpContextAccessor http)
 {
     [HttpGet("/buy/summary/{orderId}")]
-    public async Task Handle(HttpRequest request)
+    public async Task Handle(Guid orderId)
     {
-        var orderIdString = (string)request.HttpContext.GetRouteData().Values["orderId"]!;
-        var orderId = Guid.Parse(orderIdString);
+        var request = http.HttpContext!.Request;
         var ct = request.HttpContext.RequestAborted;
 
         var cart = await workflow.Read<CartSlice>(orderId, CartWorkflowSlice.Key, ct)

--- a/src/Catalog.ServiceComposition/Checkout/SummaryComposer.cs
+++ b/src/Catalog.ServiceComposition/Checkout/SummaryComposer.cs
@@ -1,4 +1,3 @@
-using System.Dynamic;
 using Catalog.ServiceComposition.Events;
 using Catalog.ServiceComposition.Workflow;
 using Microsoft.AspNetCore.Http;
@@ -20,7 +19,7 @@ public class SummaryComposer(IWorkflowStore workflow, IHttpContextAccessor http)
         var cart = await workflow.Read<CartSlice>(orderId, CartWorkflowSlice.Key, ct)
                    ?? CartSlice.Empty;
 
-        var productsModel = MapToDictionary(cart);
+        var productsModel = Mapper.MapToDictionary(cart);
 
         var context = request.GetCompositionContext();
         await context.RaiseEvent(new SummaryLoaded
@@ -32,21 +31,5 @@ public class SummaryComposer(IWorkflowStore workflow, IHttpContextAccessor http)
         var vm = request.GetComposedResponseModel();
         vm.OrderId = orderId;
         vm.Products = productsModel;
-    }
-
-    static IDictionary<Guid, dynamic> MapToDictionary(CartSlice cart)
-    {
-        var productsViewModel = new Dictionary<Guid, dynamic>();
-
-        foreach (var line in cart.Items)
-        {
-            dynamic vm = new ExpandoObject();
-            vm.ProductId = line.ProductId;
-            vm.Quantity = line.Quantity;
-
-            productsViewModel[line.ProductId] = vm;
-        }
-
-        return productsViewModel;
     }
 }

--- a/src/Catalog.ServiceComposition/Checkout/SummarySubmitComposer.cs
+++ b/src/Catalog.ServiceComposition/Checkout/SummarySubmitComposer.cs
@@ -1,7 +1,6 @@
 using Catalog.ServiceComposition.Workflow;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
 using ServiceComposer.AspNetCore;
 using WorkflowComposer;
 
@@ -14,14 +13,13 @@ namespace Catalog.ServiceComposition.Checkout;
 // per-boundary commands and CompleteOrder are guaranteed to
 // dispatch from checkout.db's outbox via the Checkout.Endpoint
 // processor.
-public class SummarySubmitComposer(IWorkflowStore store, IWorkflowSubmitter submitter) : ICompositionRequestsHandler
+[CompositionHandler]
+public class SummarySubmitComposer(IWorkflowStore store, IWorkflowSubmitter submitter, IHttpContextAccessor http)
 {
     [HttpPost("/buy/summary/{orderId}")]
-    public async Task Handle(HttpRequest request)
+    public async Task Handle(Guid orderId)
     {
-        var orderIdString = (string)request.HttpContext.GetRouteData().Values["orderId"]!;
-        var orderId = Guid.Parse(orderIdString);
-        var ct = request.HttpContext.RequestAborted;
+        var ct = http.HttpContext!.RequestAborted;
 
         await store.Write(orderId, CompleteOrderWorkflowSlice.Key, new CompleteOrderSlice(), ct);
         await submitter.Submit(orderId, ct);

--- a/src/Catalog.ServiceComposition/Email/Mapper.cs
+++ b/src/Catalog.ServiceComposition/Email/Mapper.cs
@@ -1,0 +1,34 @@
+using System.Dynamic;
+using Catalog.Data.Models;
+
+namespace Catalog.ServiceComposition.Email;
+
+// Email-summary viewmodel: one entry per ordered line, carrying the
+// product's display fields (Name, Description, ImageUrl) alongside
+// the quantity that was actually ordered. Source rows come from the
+// Order -> OrderItem -> Product join.
+public static class Mapper
+{
+    public static IDictionary<Guid, dynamic> MapToDictionary(IEnumerable<(OrderItem OrderItem, Product Product)> rows)
+    {
+        var productsViewModel = new Dictionary<Guid, dynamic>();
+
+        foreach (var row in rows)
+        {
+            productsViewModel[row.OrderItem.ProductId] = MapToViewModel(row.OrderItem, row.Product);
+        }
+
+        return productsViewModel;
+    }
+
+    public static dynamic MapToViewModel(OrderItem orderedProduct, Product product)
+    {
+        dynamic vm = new ExpandoObject();
+        vm.ProductId = orderedProduct.ProductId;
+        vm.Name = product.Name;
+        vm.Description = product.Description;
+        vm.ImageUrl = product.ImageUrl;
+        vm.Quantity = orderedProduct.Quantity;
+        return vm;
+    }
+}

--- a/src/Catalog.ServiceComposition/Email/OrderSummaryComposer.cs
+++ b/src/Catalog.ServiceComposition/Email/OrderSummaryComposer.cs
@@ -1,6 +1,4 @@
-using System.Dynamic;
 using Catalog.Data;
-using Catalog.Data.Models;
 using Catalog.ServiceComposition.Events;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -25,11 +23,7 @@ public class OrderSummaryComposer(CatalogDbContext dbContext, IHttpContextAccess
             where o.OrderId == orderId
             select new { OrderItem = i, Product = p }).ToListAsync(ct);
 
-        var productsModel = new Dictionary<Guid, dynamic>();
-        foreach (var row in rows)
-        {
-            productsModel[row.OrderItem.ProductId] = MapToViewModel(row.OrderItem, row.Product);
-        }
+        var productsModel = Mapper.MapToDictionary(rows.Select(r => (r.OrderItem, r.Product)));
 
         var context = request.GetCompositionContext();
         await context.RaiseEvent(new ProductsLoaded
@@ -40,16 +34,5 @@ public class OrderSummaryComposer(CatalogDbContext dbContext, IHttpContextAccess
         var vm = request.GetComposedResponseModel();
         vm.Products = productsModel.Values.ToList();
         vm.OrderId = orderId;
-    }
-
-    private dynamic MapToViewModel(OrderItem orderedProduct, Product product)
-    {
-        dynamic vm = new ExpandoObject();
-        vm.ProductId = orderedProduct.ProductId;
-        vm.Name = product.Name;
-        vm.Description = product.Description;
-        vm.ImageUrl = product.ImageUrl;
-        vm.Quantity = orderedProduct.Quantity;
-        return vm;
     }
 }

--- a/src/Catalog.ServiceComposition/Email/OrderSummaryComposer.cs
+++ b/src/Catalog.ServiceComposition/Email/OrderSummaryComposer.cs
@@ -9,19 +9,20 @@ using ServiceComposer.AspNetCore;
 
 namespace Catalog.ServiceComposition.Email;
 
-public class OrderSummaryComposer(CatalogDbContext dbContext) : ICompositionRequestsHandler
+[CompositionHandler]
+public class OrderSummaryComposer(CatalogDbContext dbContext, IHttpContextAccessor http)
 {
     [HttpGet("/email/summary/{orderId}")]
-    public async Task Handle(HttpRequest request)
+    public async Task Handle(Guid orderId)
     {
-        var orderData = await request.Bind<OrderData>();
+        var request = http.HttpContext!.Request;
         var ct = request.HttpContext.RequestAborted;
 
         var rows = await (
             from o in dbContext.Orders
             from i in o.Products
             join p in dbContext.Products on i.ProductId equals p.ProductId
-            where o.OrderId == orderData.OrderId
+            where o.OrderId == orderId
             select new { OrderItem = i, Product = p }).ToListAsync(ct);
 
         var productsModel = new Dictionary<Guid, dynamic>();
@@ -38,7 +39,7 @@ public class OrderSummaryComposer(CatalogDbContext dbContext) : ICompositionRequ
 
         var vm = request.GetComposedResponseModel();
         vm.Products = productsModel.Values.ToList();
-        vm.OrderId = orderData.OrderId;
+        vm.OrderId = orderId;
     }
 
     private dynamic MapToViewModel(OrderItem orderedProduct, Product product)
@@ -50,10 +51,5 @@ public class OrderSummaryComposer(CatalogDbContext dbContext) : ICompositionRequ
         vm.ImageUrl = product.ImageUrl;
         vm.Quantity = orderedProduct.Quantity;
         return vm;
-    }
-
-    class OrderData
-    {
-        [FromRoute] public Guid OrderId { get; set; }
     }
 }

--- a/src/Catalog.ServiceComposition/Products/Mapper.cs
+++ b/src/Catalog.ServiceComposition/Products/Mapper.cs
@@ -3,7 +3,7 @@ using Catalog.Data.Models;
 
 namespace Catalog.ServiceComposition.Products;
 
-public class Mapper
+public static class Mapper
 {
     public static IDictionary<Guid, dynamic> MapToDictionary(IEnumerable<Product> products, List<InventorySnapshot> inventory)
     {
@@ -12,9 +12,7 @@ public class Mapper
         foreach (var product in products)
         {
             var inventoryItem = inventory.Single(p => p.ProductId == product.ProductId);
-            var vm = MapToViewModel(product, inventoryItem);
-
-            productsViewModel[product.ProductId] = vm;
+            productsViewModel[product.ProductId] = MapToViewModel(product, inventoryItem);
         }
 
         return productsViewModel;

--- a/src/Catalog.ServiceComposition/Products/ProductComposer.cs
+++ b/src/Catalog.ServiceComposition/Products/ProductComposer.cs
@@ -8,15 +8,14 @@ using ServiceComposer.AspNetCore;
 
 namespace Catalog.ServiceComposition.Products;
 
-public class ProductComposer(CatalogDbContext dbContext) : ICompositionRequestsHandler
+[CompositionHandler]
+public class ProductComposer(CatalogDbContext dbContext, IHttpContextAccessor http)
 {
     [HttpGet("/product/{productId}")]
-    public async Task Handle(HttpRequest request)
+    public async Task Handle(Guid productId)
     {
+        var request = http.HttpContext!.Request;
         var vm = request.GetComposedResponseModel();
-
-        var productIdString = (string)request.HttpContext.GetRouteData().Values["productId"]!;
-        var productId = Guid.Parse(productIdString);
 
         var ct = request.HttpContext.RequestAborted;
         var row = await (

--- a/src/Catalog.ServiceComposition/Products/ProductsComposer.cs
+++ b/src/Catalog.ServiceComposition/Products/ProductsComposer.cs
@@ -16,14 +16,8 @@ namespace Catalog.ServiceComposition.Products;
 // ordered IDs back. Catalog has no opinion on the sort vocabulary and
 // never reads ?sort= itself.
 //
-// Query parameters:
-//   categories  comma-separated; empty -> no filter
-//   breweries   comma-separated; empty -> no filter
-//   countries   comma-separated; empty -> no filter
-//   inStock     bool, default true (0-stock items hidden)
-//   sort        consumed by subscribers; if none claims it, Catalog's default (by Name) wins
-//   page        int >= 1, default 1
-//   size        int 1-MaxPageSize, default DefaultPageSize
+// Query parameters live on ProductsQuery; the body of this handler
+// stays focused on the search/compose pipeline.
 //
 // The composed response carries:
 //   Products    list of dictionary values for the page (in order)
@@ -31,34 +25,28 @@ namespace Catalog.ServiceComposition.Products;
 [CompositionHandler]
 public class ProductsComposer(CatalogDbContext dbContext, IHttpContextAccessor http)
 {
-    const int DefaultPageSize = 12;
     const int MaxPageSize = 50;
 
     [HttpGet("/products")]
-    public async Task Handle()
+    public async Task Handle([FromQuery] ProductsQuery query)
     {
         var request = http.HttpContext!.Request;
         var ct = request.HttpContext.RequestAborted;
-        var query = request.Query;
 
-        var categories = ReadList(query, "categories");
-        var breweries = ReadList(query, "breweries");
-        var countries = ReadList(query, "countries");
-        var inStock = ReadBool(query, "inStock", defaultValue: true);
-        var page = Math.Max(1, ReadInt(query, "page", defaultValue: 1));
-        var size = Math.Clamp(ReadInt(query, "size", defaultValue: DefaultPageSize), 1, MaxPageSize);
+        var page = Math.Max(1, query.Page);
+        var size = Math.Clamp(query.Size, 1, MaxPageSize);
 
         // 1. Filter Catalog-owned attributes. Each filter only applies
         //    when the caller supplied at least one value.
         IQueryable<Product> productsQuery = dbContext.Products;
-        if (categories.Count > 0) productsQuery = productsQuery.Where(p => categories.Contains(p.Category));
-        if (breweries.Count > 0) productsQuery = productsQuery.Where(p => breweries.Contains(p.Brewery));
-        if (countries.Count > 0) productsQuery = productsQuery.Where(p => countries.Contains(p.Country));
+        if (query.CategoryList.Count > 0) productsQuery = productsQuery.Where(p => query.CategoryList.Contains(p.Category));
+        if (query.BreweryList.Count > 0) productsQuery = productsQuery.Where(p => query.BreweryList.Contains(p.Brewery));
+        if (query.CountryList.Count > 0) productsQuery = productsQuery.Where(p => query.CountryList.Contains(p.Country));
 
         // 2. Apply the in-stock filter via a join on the snapshot.
         //    The default of true keeps zero-stock items off the list,
         //    matching what users would expect on a storefront.
-        if (inStock)
+        if (query.InStock)
         {
             productsQuery =
                 from p in productsQuery
@@ -134,28 +122,5 @@ public class ProductsComposer(CatalogDbContext dbContext, IHttpContextAccessor h
         responseModel.PageSize = size;
         responseModel.TotalCount = totalCount;
         responseModel.TotalPages = totalPages;
-    }
-
-    static List<string> ReadList(IQueryCollection query, string name)
-    {
-        if (!query.TryGetValue(name, out var values))
-            return [];
-
-        return values
-            .SelectMany(v => (v ?? "").Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-            .Where(s => !string.IsNullOrWhiteSpace(s))
-            .ToList();
-    }
-
-    static bool ReadBool(IQueryCollection query, string name, bool defaultValue)
-    {
-        if (!query.TryGetValue(name, out var values) || values.Count == 0) return defaultValue;
-        return bool.TryParse(values[0], out var parsed) ? parsed : defaultValue;
-    }
-
-    static int ReadInt(IQueryCollection query, string name, int defaultValue)
-    {
-        if (!query.TryGetValue(name, out var values) || values.Count == 0) return defaultValue;
-        return int.TryParse(values[0], out var parsed) ? parsed : defaultValue;
     }
 }

--- a/src/Catalog.ServiceComposition/Products/ProductsComposer.cs
+++ b/src/Catalog.ServiceComposition/Products/ProductsComposer.cs
@@ -28,14 +28,16 @@ namespace Catalog.ServiceComposition.Products;
 // The composed response carries:
 //   Products    list of dictionary values for the page (in order)
 //   Page, PageSize, TotalCount, TotalPages
-public class ProductsComposer(CatalogDbContext dbContext) : ICompositionRequestsHandler
+[CompositionHandler]
+public class ProductsComposer(CatalogDbContext dbContext, IHttpContextAccessor http)
 {
     const int DefaultPageSize = 12;
     const int MaxPageSize = 50;
 
     [HttpGet("/products")]
-    public async Task Handle(HttpRequest request)
+    public async Task Handle()
     {
+        var request = http.HttpContext!.Request;
         var ct = request.HttpContext.RequestAborted;
         var query = request.Query;
 

--- a/src/Catalog.ServiceComposition/Products/ProductsFacetsComposer.cs
+++ b/src/Catalog.ServiceComposition/Products/ProductsFacetsComposer.cs
@@ -14,11 +14,13 @@ namespace Catalog.ServiceComposition.Products;
 // "No beers match your filter" page after the user picks one.
 //
 // Three small distinct queries; cheap enough to compute on every call.
-public class ProductsFacetsComposer(CatalogDbContext dbContext) : ICompositionRequestsHandler
+[CompositionHandler]
+public class ProductsFacetsComposer(CatalogDbContext dbContext, IHttpContextAccessor http)
 {
     [HttpGet("/products/facets")]
-    public async Task Handle(HttpRequest request)
+    public async Task Handle()
     {
+        var request = http.HttpContext!.Request;
         var ct = request.HttpContext.RequestAborted;
 
         IQueryable<Product> inStockProducts =

--- a/src/Catalog.ServiceComposition/Products/ProductsQuery.cs
+++ b/src/Catalog.ServiceComposition/Products/ProductsQuery.cs
@@ -1,0 +1,28 @@
+namespace Catalog.ServiceComposition.Products;
+
+// Declarative query-string model for GET /products. ServiceComposer's
+// model binder fills each property from the corresponding query key
+// (case-insensitive). The comma-separated filters arrive as a single
+// string so we keep them as strings here and split on access; that
+// matches the frontend, which builds `?categories=a,b,c`.
+public class ProductsQuery
+{
+    public string? Categories { get; set; }
+    public string? Breweries { get; set; }
+    public string? Countries { get; set; }
+    public bool InStock { get; set; } = true;
+    public string? Sort { get; set; }
+    public int Page { get; set; } = 1;
+    public int Size { get; set; } = 12;
+
+    public IReadOnlyList<string> CategoryList => Split(Categories);
+    public IReadOnlyList<string> BreweryList => Split(Breweries);
+    public IReadOnlyList<string> CountryList => Split(Countries);
+
+    static List<string> Split(string? value) =>
+        string.IsNullOrWhiteSpace(value)
+            ? []
+            : value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .ToList();
+}

--- a/src/Catalog.ServiceComposition/Products/SummaryLoadedSubscriber.cs
+++ b/src/Catalog.ServiceComposition/Products/SummaryLoadedSubscriber.cs
@@ -1,29 +1,25 @@
 using Catalog.Data;
 using Catalog.ServiceComposition.Events;
-using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using ServiceComposer.AspNetCore;
 
 namespace Finance.ServiceComposition.Products;
 
-public class SummaryLoadedSubscriber(CatalogDbContext dbContext) : ICompositionEventsSubscriber
+public class SummaryLoadedSubscriber(CatalogDbContext dbContext) : ICompositionEventsHandler<SummaryLoaded>
 {
-    [HttpGet("buy/summary/{orderId}")]
-    public void Subscribe(ICompositionEventsPublisher publisher)
+    public async Task Handle(SummaryLoaded @event, HttpRequest request)
     {
-        publisher.Subscribe<SummaryLoaded>(async (@event, request) =>
-        {
-            var productIds = @event.Products.Keys.ToList();
-            var products = await dbContext.Products
-                .Where(s => productIds.Contains(s.ProductId))
-                .ToListAsync(request.HttpContext.RequestAborted);
+        var productIds = @event.Products.Keys.ToList();
+        var products = await dbContext.Products
+            .Where(s => productIds.Contains(s.ProductId))
+            .ToListAsync(request.HttpContext.RequestAborted);
 
-            foreach (var productItem in @event.Products)
-            {
-                var product = products.SingleOrDefault(p => p.ProductId == productItem.Key);
-                productItem.Value.Name = product?.Name;
-                productItem.Value.ImageUrl = product?.ImageUrl;
-            }
-        });
+        foreach (var productItem in @event.Products)
+        {
+            var product = products.SingleOrDefault(p => p.ProductId == productItem.Key);
+            productItem.Value.Name = product?.Name;
+            productItem.Value.ImageUrl = product?.ImageUrl;
+        }
     }
 }

--- a/src/Catalog.ServiceComposition/ShoppingCart/Mapper.cs
+++ b/src/Catalog.ServiceComposition/ShoppingCart/Mapper.cs
@@ -12,17 +12,20 @@ public static class Mapper
 
         foreach (var line in cart.Items)
         {
-            dynamic vm = new ExpandoObject();
-            vm.ProductId = line.ProductId;
-            vm.Quantity = line.Quantity;
-
             var matchingProduct = products.Single(p => p.ProductId == line.ProductId);
-            vm.Name = matchingProduct.Name;
-            vm.ImageUrl = matchingProduct.ImageUrl;
-
-            productsViewModel[line.ProductId] = vm;
+            productsViewModel[line.ProductId] = MapToViewModel(line, matchingProduct);
         }
 
         return productsViewModel;
+    }
+
+    public static dynamic MapToViewModel(CartLine line, Product product)
+    {
+        dynamic vm = new ExpandoObject();
+        vm.ProductId = line.ProductId;
+        vm.Quantity = line.Quantity;
+        vm.Name = product.Name;
+        vm.ImageUrl = product.ImageUrl;
+        return vm;
     }
 }

--- a/src/Catalog.ServiceComposition/ShoppingCart/ShoppingCartAddItemComposer.cs
+++ b/src/Catalog.ServiceComposition/ShoppingCart/ShoppingCartAddItemComposer.cs
@@ -10,7 +10,7 @@ namespace Catalog.ServiceComposition.ShoppingCart;
 public class ShoppingCartAddItemComposer(IWorkflowStore workflow, IHttpContextAccessor http)
 {
     [HttpPost("/cart/addproduct/{orderId}")]
-    public async Task Handle(Guid orderId, [FromBody] ProductModelBody detail)
+    public async Task Handle(Guid orderId, [FromBody] AddProductForm form)
     {
         var request = http.HttpContext!.Request;
         var ct = request.HttpContext.RequestAborted;
@@ -20,7 +20,7 @@ public class ShoppingCartAddItemComposer(IWorkflowStore workflow, IHttpContextAc
 
         var cart = await workflow.Read<CartSlice>(orderId, CartWorkflowSlice.Key, ct)
                    ?? CartSlice.Empty;
-        var updated = Upsert(cart, detail.Id, detail.Quantity);
+        var updated = Upsert(cart, form.Id, form.Quantity);
         await workflow.Write(orderId, CartWorkflowSlice.Key, updated, ct);
 
         var vm = request.GetComposedResponseModel();
@@ -46,9 +46,4 @@ public class ShoppingCartAddItemComposer(IWorkflowStore workflow, IHttpContextAc
         return new CartSlice(lines);
     }
 
-    public class ProductModelBody
-    {
-        public Guid Id { get; set; }
-        public int Quantity { get; set; }
-    }
 }

--- a/src/Catalog.ServiceComposition/ShoppingCart/ShoppingCartAddItemComposer.cs
+++ b/src/Catalog.ServiceComposition/ShoppingCart/ShoppingCartAddItemComposer.cs
@@ -6,14 +6,13 @@ using WorkflowComposer;
 
 namespace Catalog.ServiceComposition.ShoppingCart;
 
-public class ShoppingCartAddItemComposer(IWorkflowStore workflow) : ICompositionRequestsHandler
+[CompositionHandler]
+public class ShoppingCartAddItemComposer(IWorkflowStore workflow, IHttpContextAccessor http)
 {
     [HttpPost("/cart/addproduct/{orderId}")]
-    public async Task Handle(HttpRequest request)
+    public async Task Handle(Guid orderId, [FromBody] ProductModelBody detail)
     {
-        var productToAdd = await request.Bind<ProductModel>();
-        var orderId = productToAdd.orderId;
-        var productId = productToAdd.Detail.Id;
+        var request = http.HttpContext!.Request;
         var ct = request.HttpContext.RequestAborted;
 
         if (orderId == Guid.Empty)
@@ -21,7 +20,7 @@ public class ShoppingCartAddItemComposer(IWorkflowStore workflow) : IComposition
 
         var cart = await workflow.Read<CartSlice>(orderId, CartWorkflowSlice.Key, ct)
                    ?? CartSlice.Empty;
-        var updated = Upsert(cart, productId, productToAdd.Detail.Quantity);
+        var updated = Upsert(cart, detail.Id, detail.Quantity);
         await workflow.Write(orderId, CartWorkflowSlice.Key, updated, ct);
 
         var vm = request.GetComposedResponseModel();
@@ -47,13 +46,7 @@ public class ShoppingCartAddItemComposer(IWorkflowStore workflow) : IComposition
         return new CartSlice(lines);
     }
 
-    class ProductModel
-    {
-        [FromRoute] public Guid orderId { get; set; }
-        [FromBody] public ProductModelBody Detail { get; set; } = null!;
-    }
-
-    class ProductModelBody
+    public class ProductModelBody
     {
         public Guid Id { get; set; }
         public int Quantity { get; set; }

--- a/src/Catalog.ServiceComposition/ShoppingCart/ShoppingCartComposer.cs
+++ b/src/Catalog.ServiceComposition/ShoppingCart/ShoppingCartComposer.cs
@@ -3,21 +3,20 @@ using Catalog.ServiceComposition.Events;
 using Catalog.ServiceComposition.Workflow;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using ServiceComposer.AspNetCore;
 using WorkflowComposer;
 
 namespace Catalog.ServiceComposition.ShoppingCart;
 
-public class ShoppingCartComposer(IWorkflowStore workflow, CatalogDbContext dbContext) : ICompositionRequestsHandler
+[CompositionHandler]
+public class ShoppingCartComposer(IWorkflowStore workflow, CatalogDbContext dbContext, IHttpContextAccessor http)
 {
     [HttpGet("/cart/{orderId}")]
-    public async Task Handle(HttpRequest request)
+    public async Task Handle(Guid orderId)
     {
+        var request = http.HttpContext!.Request;
         var vm = request.GetComposedResponseModel();
-        var orderIdString = (string)request.HttpContext.GetRouteData().Values["orderId"]!;
-        var orderId = Guid.Parse(orderIdString);
         var ct = request.HttpContext.RequestAborted;
 
         var cart = await workflow.Read<CartSlice>(orderId, CartWorkflowSlice.Key, ct)

--- a/src/Catalog.ServiceComposition/ShoppingCart/ShoppingCartExistsComposer.cs
+++ b/src/Catalog.ServiceComposition/ShoppingCart/ShoppingCartExistsComposer.cs
@@ -1,20 +1,19 @@
 using Catalog.ServiceComposition.Workflow;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
 using ServiceComposer.AspNetCore;
 using WorkflowComposer;
 
 namespace Catalog.ServiceComposition.ShoppingCart;
 
-public class ShoppingCartExistsComposer(IWorkflowStore workflow) : ICompositionRequestsHandler
+[CompositionHandler]
+public class ShoppingCartExistsComposer(IWorkflowStore workflow, IHttpContextAccessor http)
 {
     [HttpGet("/existingCart/{orderId}")]
-    public async Task Handle(HttpRequest request)
+    public async Task Handle(Guid orderId)
     {
+        var request = http.HttpContext!.Request;
         var vm = request.GetComposedResponseModel();
-        var orderIdString = (string)request.HttpContext.GetRouteData().Values["orderId"]!;
-        var orderId = Guid.Parse(orderIdString);
         var ct = request.HttpContext.RequestAborted;
 
         if (orderId == Guid.Empty)

--- a/src/Catalog.ServiceComposition/Workflow/AddProductForm.cs
+++ b/src/Catalog.ServiceComposition/Workflow/AddProductForm.cs
@@ -1,0 +1,11 @@
+namespace Catalog.ServiceComposition.Workflow;
+
+// Wire shape of the POST /cart/addproduct/{orderId} body. The frontend
+// posts { id, quantity } where `id` is the product to add and
+// `quantity` is the +/- delta to apply (negative to decrement, large
+// negative to remove). Upserted into the CartSlice.
+public class AddProductForm
+{
+    public Guid Id { get; set; }
+    public int Quantity { get; set; }
+}

--- a/src/Catalog.ServiceComposition/Workflow/CartItemForm.cs
+++ b/src/Catalog.ServiceComposition/Workflow/CartItemForm.cs
@@ -1,0 +1,11 @@
+namespace Catalog.ServiceComposition.Workflow;
+
+// Wire shape of one line item in the POST /cart/{orderId} JSON array.
+// Translated into a CartSlice.CartLine by OrderSubmitComposer. Kept
+// separate from CartLine so the wire format and the slice's internal
+// shape can evolve independently.
+public class CartItemForm
+{
+    public Guid ProductId { get; set; }
+    public int Quantity { get; set; }
+}

--- a/src/CompositionGateway/CompositionGateway.csproj
+++ b/src/CompositionGateway/CompositionGateway.csproj
@@ -8,17 +8,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0"/>
-        <!-- ServiceComposer.AspNetCore 2.1.0 caps DependencyModel below 9.0.0;
-             EF Core 10 (transitively pulled in via the *.ServiceComposition
-             projects) wants 10.0.0+. Pin the higher version explicitly here. -->
-        <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.0" />
         <!-- Required so dotnet-ef can target Marketing.Data via this project as
              startup-project (Marketing has no separate endpoint to use). -->
         <PackageReference Include="NServiceBus" Version="10.1.4" />
         <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.0.1" />
-        <PackageReference Include="ServiceComposer.AspNetCore" Version="2.1.0" />
+        <PackageReference Include="ServiceComposer.AspNetCore" Version="5.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/CompositionGateway/Program.cs
+++ b/src/CompositionGateway/Program.cs
@@ -18,6 +18,7 @@ builder.Services.AddCors(options =>
                 policy.WithOrigins("https://127.0.0.1:5173", "https://localhost:5173")
                        .AllowAnyHeader();
             }));
+builder.Services.AddHttpContextAccessor();
 builder.Services.AddViewModelComposition();
 builder.Services.AddControllers();
 

--- a/src/Finance.ServiceComposition/Checkout/AddressComposer.cs
+++ b/src/Finance.ServiceComposition/Checkout/AddressComposer.cs
@@ -1,20 +1,19 @@
 using Finance.ServiceComposition.Workflow;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
 using ServiceComposer.AspNetCore;
 using WorkflowComposer;
 
 namespace Finance.ServiceComposition.Checkout;
 
-public class AddressComposer(IWorkflowStore workflow) : ICompositionRequestsHandler
+[CompositionHandler]
+public class AddressComposer(IWorkflowStore workflow, IHttpContextAccessor http)
 {
     [HttpGet("/buy/address/{orderId}")]
-    public async Task Handle(HttpRequest request)
+    public async Task Handle(Guid orderId)
     {
+        var request = http.HttpContext!.Request;
         var vm = request.GetComposedResponseModel();
-        var orderIdString = (string)request.HttpContext.GetRouteData().Values["orderId"]!;
-        var orderId = Guid.Parse(orderIdString);
         var ct = request.HttpContext.RequestAborted;
 
         // The slice holds whatever the user entered earlier in this

--- a/src/Finance.ServiceComposition/Checkout/AddressSubmitComposer.cs
+++ b/src/Finance.ServiceComposition/Checkout/AddressSubmitComposer.cs
@@ -6,29 +6,23 @@ using WorkflowComposer;
 
 namespace Finance.ServiceComposition.Checkout;
 
-public class AddressSubmitComposer(IWorkflowStore workflow) : ICompositionRequestsHandler
+[CompositionHandler]
+public class AddressSubmitComposer(IWorkflowStore workflow, IHttpContextAccessor http)
 {
     [HttpPost("/buy/address/{orderId}")]
-    public async Task Handle(HttpRequest request)
+    public async Task Handle(Guid orderId, [FromBody] OrderAddress details)
     {
-        var submitted = await request.Bind<OrderAddressDetails>();
-        var ct = request.HttpContext.RequestAborted;
+        var ct = http.HttpContext!.RequestAborted;
 
         await workflow.Write(
-            submitted.OrderId,
+            orderId,
             BillingAddressWorkflowSlice.Key,
-            new BillingAddressSlice(submitted.Details.BillingAddress),
+            new BillingAddressSlice(details.BillingAddress),
             ct);
     }
 
-    class OrderAddressDetails
+    public class OrderAddress
     {
-        [FromRoute] public Guid OrderId { get; set; }
-        [FromBody] public OrderAddress Details { get; set; } = null!;
-
-        public class OrderAddress
-        {
-            public BillingAddressData BillingAddress { get; set; } = null!;
-        }
+        public BillingAddressData BillingAddress { get; set; } = null!;
     }
 }

--- a/src/Finance.ServiceComposition/Checkout/AddressSubmitComposer.cs
+++ b/src/Finance.ServiceComposition/Checkout/AddressSubmitComposer.cs
@@ -10,19 +10,14 @@ namespace Finance.ServiceComposition.Checkout;
 public class AddressSubmitComposer(IWorkflowStore workflow, IHttpContextAccessor http)
 {
     [HttpPost("/buy/address/{orderId}")]
-    public async Task Handle(Guid orderId, [FromBody] OrderAddress details)
+    public async Task Handle(Guid orderId, [FromBody] BillingAddressForm form)
     {
         var ct = http.HttpContext!.RequestAborted;
 
         await workflow.Write(
             orderId,
             BillingAddressWorkflowSlice.Key,
-            new BillingAddressSlice(details.BillingAddress),
+            new BillingAddressSlice(form.BillingAddress),
             ct);
-    }
-
-    public class OrderAddress
-    {
-        public BillingAddressData BillingAddress { get; set; } = null!;
     }
 }

--- a/src/Finance.ServiceComposition/Checkout/DeliveryOptionSubmitComposer.cs
+++ b/src/Finance.ServiceComposition/Checkout/DeliveryOptionSubmitComposer.cs
@@ -6,25 +6,19 @@ using WorkflowComposer;
 
 namespace Finance.ServiceComposition.Checkout;
 
-public class DeliveryOptionSubmitComposer(IWorkflowStore workflow) : ICompositionRequestsHandler
+[CompositionHandler]
+public class DeliveryOptionSubmitComposer(IWorkflowStore workflow, IHttpContextAccessor http)
 {
     [HttpPost("/buy/shipping/{orderId}")]
-    public async Task Handle(HttpRequest request)
+    public async Task Handle(Guid orderId, [FromBody] SelectedDeliveryOption body)
     {
-        var submitted = await request.Bind<SelectedDeliveryOption>();
-        var ct = request.HttpContext.RequestAborted;
+        var ct = http.HttpContext!.RequestAborted;
 
-        var slice = new DeliveryOptionSlice(submitted.Body.DeliveryOptionId);
-        await workflow.Write(submitted.OrderId, DeliveryOptionWorkflowSlice.Key, slice, ct);
+        var slice = new DeliveryOptionSlice(body.DeliveryOptionId);
+        await workflow.Write(orderId, DeliveryOptionWorkflowSlice.Key, slice, ct);
     }
 
-    class SelectedDeliveryOption
-    {
-        [FromRoute] public Guid OrderId { get; set; }
-        [FromBody] public BodyModel Body { get; set; } = null!;
-    }
-
-    class BodyModel
+    public class SelectedDeliveryOption
     {
         public Guid DeliveryOptionId { get; set; }
     }

--- a/src/Finance.ServiceComposition/Checkout/DeliveryOptionSubmitComposer.cs
+++ b/src/Finance.ServiceComposition/Checkout/DeliveryOptionSubmitComposer.cs
@@ -10,16 +10,11 @@ namespace Finance.ServiceComposition.Checkout;
 public class DeliveryOptionSubmitComposer(IWorkflowStore workflow, IHttpContextAccessor http)
 {
     [HttpPost("/buy/shipping/{orderId}")]
-    public async Task Handle(Guid orderId, [FromBody] SelectedDeliveryOption body)
+    public async Task Handle(Guid orderId, [FromBody] DeliveryOptionForm form)
     {
         var ct = http.HttpContext!.RequestAborted;
 
-        var slice = new DeliveryOptionSlice(body.DeliveryOptionId);
+        var slice = new DeliveryOptionSlice(form.DeliveryOptionId);
         await workflow.Write(orderId, DeliveryOptionWorkflowSlice.Key, slice, ct);
-    }
-
-    public class SelectedDeliveryOption
-    {
-        public Guid DeliveryOptionId { get; set; }
     }
 }

--- a/src/Finance.ServiceComposition/Checkout/DeliverySummaryLoadedSubscriber.cs
+++ b/src/Finance.ServiceComposition/Checkout/DeliverySummaryLoadedSubscriber.cs
@@ -1,27 +1,22 @@
 using Finance.Data;
 using Finance.ServiceComposition.Helpers;
-using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using ServiceComposer.AspNetCore;
 using Shipping.ServiceComposition.Events;
 
 namespace Finance.ServiceComposition.Checkout;
 
-public class DeliverySummaryLoadedSubscriber(FinanceDbContext dbContext) : ICompositionEventsSubscriber
+public class DeliverySummaryLoadedSubscriber(FinanceDbContext dbContext) : ICompositionEventsHandler<DeliverySummaryLoaded>
 {
-    [HttpGet("/buy/payment/{orderId}")]
-    [HttpGet("/buy/summary/{orderId}")]
-    public void Subscribe(ICompositionEventsPublisher publisher)
+    public async Task Handle(DeliverySummaryLoaded @event, HttpRequest request)
     {
-        publisher.Subscribe<DeliverySummaryLoaded>(async (@event, request) =>
-        {
-            var deliveryOption = await dbContext.DeliveryOptions
-                .SingleAsync(s => s.DeliveryOptionId == @event.DeliveryOptionId, request.HttpContext.RequestAborted);
+        var deliveryOption = await dbContext.DeliveryOptions
+            .SingleAsync(s => s.DeliveryOptionId == @event.DeliveryOptionId, request.HttpContext.RequestAborted);
 
-            @event.DeliveryOption.Price = deliveryOption.Price;
+        @event.DeliveryOption.Price = deliveryOption.Price;
 
-            var vm = request.GetComposedResponseModel();
-            DynamicHelper.TrySetTotalPrice(vm, deliveryOption.Price);
-        });
+        var vm = request.GetComposedResponseModel();
+        DynamicHelper.TrySetTotalPrice(vm, deliveryOption.Price);
     }
 }

--- a/src/Finance.ServiceComposition/Checkout/OrderSubmitComposer.cs
+++ b/src/Finance.ServiceComposition/Checkout/OrderSubmitComposer.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using System.Text.Json;
 using Finance.ServiceComposition.Workflow;
 using Microsoft.AspNetCore.Http;
@@ -8,38 +7,28 @@ using WorkflowComposer;
 
 namespace Finance.ServiceComposition.Checkout;
 
-public class OrderSubmitComposer(IWorkflowStore workflow) : ICompositionRequestsHandler
+// Body is a raw JSON array of ShoppingCartItem; read it directly from
+// request.Body rather than via [FromBody]. See Catalog's matching
+// OrderSubmitComposer for the rationale.
+[CompositionHandler]
+public class OrderSubmitComposer(IWorkflowStore workflow, IHttpContextAccessor http)
 {
+    static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
     [HttpPost("/cart/{orderId}")]
-    public async Task Handle(HttpRequest request)
+    public async Task Handle(Guid orderId)
     {
-        var submitted = await request.Bind<ShoppingCart>();
+        var request = http.HttpContext!.Request;
         var ct = request.HttpContext.RequestAborted;
+        var items = await JsonSerializer.DeserializeAsync<List<ShoppingCartItem>>(request.Body, JsonOptions, ct) ?? [];
 
-        request.Body.Position = 0;
-        using var reader = new StreamReader(request.Body, Encoding.UTF8, leaveOpen: true);
-        var body = await reader.ReadToEndAsync(ct);
-        var shoppingCartItems = JsonSerializer.Deserialize<List<ShoppingCartItem>>(body,
-            new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? [];
-
-        var slice = new OrderItemsSlice(shoppingCartItems
+        var slice = new OrderItemsSlice(items
             .Select(i => new OrderItemLine(i.ProductId, i.Quantity))
             .ToList());
-        await workflow.Write(submitted.OrderId, OrderItemsWorkflowSlice.Key, slice, ct);
+        await workflow.Write(orderId, OrderItemsWorkflowSlice.Key, slice, ct);
     }
 
-    class ShoppingCart
-    {
-        [FromRoute] public Guid OrderId { get; set; }
-        [FromBody] public ShoppingCartModel Model { get; set; } = null!;
-    }
-
-    class ShoppingCartModel
-    {
-        public Guid OrderId { get; set; }
-    }
-
-    class ShoppingCartItem
+    public class ShoppingCartItem
     {
         public Guid ProductId { get; set; }
         public int Quantity { get; set; }

--- a/src/Finance.ServiceComposition/Checkout/OrderSubmitComposer.cs
+++ b/src/Finance.ServiceComposition/Checkout/OrderSubmitComposer.cs
@@ -24,17 +24,11 @@ public class OrderSubmitComposer(IWorkflowStore workflow, IHttpContextAccessor h
         // also reads the body. ServiceComposer enables buffering, so rewind
         // before each read so whichever composer runs second still sees JSON.
         request.Body.Position = 0;
-        var items = await JsonSerializer.DeserializeAsync<List<ShoppingCartItem>>(request.Body, JsonOptions, ct) ?? [];
+        var items = await JsonSerializer.DeserializeAsync<List<CartItemForm>>(request.Body, JsonOptions, ct) ?? [];
 
         var slice = new OrderItemsSlice(items
             .Select(i => new OrderItemLine(i.ProductId, i.Quantity))
             .ToList());
         await workflow.Write(orderId, OrderItemsWorkflowSlice.Key, slice, ct);
-    }
-
-    public class ShoppingCartItem
-    {
-        public Guid ProductId { get; set; }
-        public int Quantity { get; set; }
     }
 }

--- a/src/Finance.ServiceComposition/Checkout/OrderSubmitComposer.cs
+++ b/src/Finance.ServiceComposition/Checkout/OrderSubmitComposer.cs
@@ -20,6 +20,10 @@ public class OrderSubmitComposer(IWorkflowStore workflow, IHttpContextAccessor h
     {
         var request = http.HttpContext!.Request;
         var ct = request.HttpContext.RequestAborted;
+        // Catalog has a matching OrderSubmitComposer on the same route that
+        // also reads the body. ServiceComposer enables buffering, so rewind
+        // before each read so whichever composer runs second still sees JSON.
+        request.Body.Position = 0;
         var items = await JsonSerializer.DeserializeAsync<List<ShoppingCartItem>>(request.Body, JsonOptions, ct) ?? [];
 
         var slice = new OrderItemsSlice(items

--- a/src/Finance.ServiceComposition/Checkout/SummaryLoadedSubscriber.cs
+++ b/src/Finance.ServiceComposition/Checkout/SummaryLoadedSubscriber.cs
@@ -3,63 +3,59 @@ using Finance.Data;
 using Finance.Data.Models;
 using Finance.ServiceComposition.Helpers;
 using Finance.ServiceComposition.Workflow;
-using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using ServiceComposer.AspNetCore;
 using WorkflowComposer;
 
 namespace Finance.ServiceComposition.Checkout;
 
-public class SummaryLoadedSubscriber(FinanceDbContext dbContext, IWorkflowStore workflow) : ICompositionEventsSubscriber
+public class SummaryLoadedSubscriber(FinanceDbContext dbContext, IWorkflowStore workflow) : ICompositionEventsHandler<SummaryLoaded>
 {
-    [HttpGet("/buy/summary/{orderId}")]
-    public void Subscribe(ICompositionEventsPublisher publisher)
+    public async Task Handle(SummaryLoaded @event, HttpRequest request)
     {
-        publisher.Subscribe<SummaryLoaded>(async (@event, request) =>
+        var orderId = @event.OrderId;
+        var ct = request.HttpContext.RequestAborted;
+
+        var order = await dbContext.Orders
+            .Include(o => o.Items)
+            .FirstOrDefaultAsync(s => s.OrderId == orderId, ct);
+
+        if (order == null)
         {
-            var orderId = @event.OrderId;
-            var ct = request.HttpContext.RequestAborted;
-
-            var order = await dbContext.Orders
-                .Include(o => o.Items)
-                .FirstOrDefaultAsync(s => s.OrderId == orderId, ct);
-
-            if (order == null)
+            // Finance hasn't processed SubmitOrderItems yet - fall
+            // back to the in-flight slice. The slice carries no
+            // prices (those are domain-owned and only get populated
+            // by Finance's handler), so the totals come out as 0
+            // until the message is dispatched and processed.
+            var slice = await workflow.Read<OrderItemsSlice>(orderId, OrderItemsWorkflowSlice.Key, ct);
+            order = new Order { OrderId = orderId };
+            if (slice is not null)
             {
-                // Finance hasn't processed SubmitOrderItems yet - fall
-                // back to the in-flight slice. The slice carries no
-                // prices (those are domain-owned and only get populated
-                // by Finance's handler), so the totals come out as 0
-                // until the message is dispatched and processed.
-                var slice = await workflow.Read<OrderItemsSlice>(orderId, OrderItemsWorkflowSlice.Key, ct);
-                order = new Order { OrderId = orderId };
-                if (slice is not null)
+                foreach (var line in slice.Items)
                 {
-                    foreach (var line in slice.Items)
+                    order.Items.Add(new OrderItem
                     {
-                        order.Items.Add(new OrderItem
-                        {
-                            OrderId = orderId,
-                            ProductId = line.ProductId,
-                            Quantity = line.Quantity
-                        });
-                    }
+                        OrderId = orderId,
+                        ProductId = line.ProductId,
+                        Quantity = line.Quantity
+                    });
                 }
             }
+        }
 
-            var totalPrice = 0m;
+        var totalPrice = 0m;
 
-            foreach (var product in @event.Products)
-            {
-                var matchingProduct = order.Items.SingleOrDefault(s => s.ProductId == product.Key);
-                if (matchingProduct is null) continue;
-                product.Value.Price = matchingProduct.Price;
-                product.Value.Discount = matchingProduct.Discount;
-                totalPrice += matchingProduct.EffectivePrice() * matchingProduct.Quantity;
-            }
+        foreach (var product in @event.Products)
+        {
+            var matchingProduct = order.Items.SingleOrDefault(s => s.ProductId == product.Key);
+            if (matchingProduct is null) continue;
+            product.Value.Price = matchingProduct.Price;
+            product.Value.Discount = matchingProduct.Discount;
+            totalPrice += matchingProduct.EffectivePrice() * matchingProduct.Quantity;
+        }
 
-            var vm = request.GetComposedResponseModel();
-            DynamicHelper.TrySetTotalPrice(vm, totalPrice);
-        });
+        var vm = request.GetComposedResponseModel();
+        DynamicHelper.TrySetTotalPrice(vm, totalPrice);
     }
 }

--- a/src/Finance.ServiceComposition/DeliveryOptions/DeliveryOptionsLoadedSubscriber.cs
+++ b/src/Finance.ServiceComposition/DeliveryOptions/DeliveryOptionsLoadedSubscriber.cs
@@ -1,26 +1,22 @@
 using Finance.Data;
-using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using ServiceComposer.AspNetCore;
 using Shipping.ServiceComposition.Events;
 
 namespace Finance.ServiceComposition.DeliveryOptions;
 
-public class DeliveryOptionsLoadedSubscriber(FinanceDbContext dbContext) : ICompositionEventsSubscriber
+public class DeliveryOptionsLoadedSubscriber(FinanceDbContext dbContext) : ICompositionEventsHandler<DeliveryOptionsLoaded>
 {
-    [HttpGet("/buy/shipping/{orderId}")]
-    public void Subscribe(ICompositionEventsPublisher publisher)
+    public async Task Handle(DeliveryOptionsLoaded @event, HttpRequest request)
     {
-        publisher.Subscribe<DeliveryOptionsLoaded>(async (@event, request) =>
-        {
-            var results = await dbContext.DeliveryOptions
-                .ToListAsync(request.HttpContext.RequestAborted);
+        var results = await dbContext.DeliveryOptions
+            .ToListAsync(request.HttpContext.RequestAborted);
 
-            foreach (var deliveryOption in @event.DeliveryOptions)
-            {
-                var matchingOption = results.Single(s => s.DeliveryOptionId == deliveryOption.Key);
-                deliveryOption.Value.Price = matchingOption.Price;
-            }
-        });
+        foreach (var deliveryOption in @event.DeliveryOptions)
+        {
+            var matchingOption = results.Single(s => s.DeliveryOptionId == deliveryOption.Key);
+            deliveryOption.Value.Price = matchingOption.Price;
+        }
     }
 }

--- a/src/Finance.ServiceComposition/Email/OrderSummaryComposer.cs
+++ b/src/Finance.ServiceComposition/Email/OrderSummaryComposer.cs
@@ -11,12 +11,13 @@ using Shipping.ServiceComposition.Events;
 
 namespace Finance.ServiceComposition.Email;
 
-public class OrderSummaryComposer(FinanceDbContext dbContext) : ICompositionRequestsHandler
+[CompositionHandler]
+public class OrderSummaryComposer(FinanceDbContext dbContext, IHttpContextAccessor http)
 {
     [HttpGet("/email/summary/{orderId}")]
-    public async Task Handle(HttpRequest request)
+    public async Task Handle(Guid orderId)
     {
-        var orderData = await request.Bind<OrderData>();
+        var request = http.HttpContext!.Request;
         var ct = request.HttpContext.RequestAborted;
 
         // The email summary fires on OrderShipped, so by this point a
@@ -25,7 +26,7 @@ public class OrderSummaryComposer(FinanceDbContext dbContext) : ICompositionRequ
         var row = await (
             from o in dbContext.Orders.Include(o => o.Items)
             join d in dbContext.DeliveryOptions on o.DeliveryOptionId equals d.DeliveryOptionId
-            where o.OrderId == orderData.OrderId
+            where o.OrderId == orderId
             select new { Order = o, DeliveryOption = d }).SingleAsync(ct);
 
         var order = row.Order;
@@ -50,10 +51,5 @@ public class OrderSummaryComposer(FinanceDbContext dbContext) : ICompositionRequ
             order.BillingAddress.Country);
         vm.DeliveryOption = deliveryOptionModel;
         vm.TotalPrice = order.Items.Sum(s => s.EffectivePrice() * s.Quantity) + deliveryOption.Price;
-    }
-
-    class OrderData
-    {
-        [FromRoute] public Guid OrderId { get; set; }
     }
 }

--- a/src/Finance.ServiceComposition/Finance.ServiceComposition.csproj
+++ b/src/Finance.ServiceComposition/Finance.ServiceComposition.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
-      <PackageReference Include="ServiceComposer.AspNetCore" Version="2.1.0" />
+      <PackageReference Include="ServiceComposer.AspNetCore" Version="5.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Finance.ServiceComposition/Orders/CartLoadedSubscriber.cs
+++ b/src/Finance.ServiceComposition/Orders/CartLoadedSubscriber.cs
@@ -1,37 +1,32 @@
 using Catalog.ServiceComposition.Events;
 using Finance.Data;
 using Finance.Data.Models;
-using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using ServiceComposer.AspNetCore;
 
 namespace Finance.ServiceComposition.Orders;
 
-public class CartLoadedSubscriber(FinanceDbContext dbContext) : ICompositionEventsSubscriber
+public class CartLoadedSubscriber(FinanceDbContext dbContext) : ICompositionEventsHandler<CartLoaded>
 {
-    [HttpGet("/cart/{orderId}")]
-    [HttpGet("/buy/shipping/{orderId}")]
-    public void Subscribe(ICompositionEventsPublisher publisher)
+    public async Task Handle(CartLoaded @event, HttpRequest request)
     {
-        publisher.Subscribe<CartLoaded>(async (@event, request) =>
+        var productIds = @event.OrderedProducts.Keys.ToList();
+        var resultSet = await dbContext.Products
+            .Where(s => productIds.Contains(s.ProductId))
+            .ToListAsync(request.HttpContext.RequestAborted);
+
+        decimal totalPrice = 0;
+        foreach (var product in @event.OrderedProducts)
         {
-            var productIds = @event.OrderedProducts.Keys.ToList();
-            var resultSet = await dbContext.Products
-                .Where(s => productIds.Contains(s.ProductId))
-                .ToListAsync(request.HttpContext.RequestAborted);
+            var matchingProduct = resultSet.Single(s => s.ProductId == product.Key);
+            product.Value.Price = matchingProduct.Price;
+            product.Value.Discount = matchingProduct.Discount;
 
-            decimal totalPrice = 0;
-            foreach (var product in @event.OrderedProducts)
-            {
-                var matchingProduct = resultSet.Single(s => s.ProductId == product.Key);
-                product.Value.Price = matchingProduct.Price;
-                product.Value.Discount = matchingProduct.Discount;
+            totalPrice += matchingProduct.EffectivePrice() * (int)product.Value.Quantity;
+        }
 
-                totalPrice += matchingProduct.EffectivePrice() * (int)product.Value.Quantity;
-            }
-
-            var vm = request.GetComposedResponseModel();
-            vm.TotalCartPrice = totalPrice;
-        });
+        var vm = request.GetComposedResponseModel();
+        vm.TotalCartPrice = totalPrice;
     }
 }

--- a/src/Finance.ServiceComposition/Orders/CartSummaryLoadedSubscriber.cs
+++ b/src/Finance.ServiceComposition/Orders/CartSummaryLoadedSubscriber.cs
@@ -1,7 +1,7 @@
 using Catalog.ServiceComposition.Events;
 using Finance.Data;
 using Finance.Data.Models;
-using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using ServiceComposer.AspNetCore;
 
@@ -12,31 +12,26 @@ namespace Finance.ServiceComposition.Orders;
 // Products view, and exposes the cart total. The shipping route uses
 // the heavier `CartLoadedSubscriber`/`CartLoaded` pair instead, because
 // it also renders product names/images.
-public class CartSummaryLoadedSubscriber(FinanceDbContext dbContext) : ICompositionEventsSubscriber
+public class CartSummaryLoadedSubscriber(FinanceDbContext dbContext) : ICompositionEventsHandler<CartSummaryLoaded>
 {
-    [HttpGet("/buy/address/{orderId}")]
-    [HttpGet("/buy/payment/{orderId}")]
-    public void Subscribe(ICompositionEventsPublisher publisher)
+    public async Task Handle(CartSummaryLoaded @event, HttpRequest request)
     {
-        publisher.Subscribe<CartSummaryLoaded>(async (@event, request) =>
+        var productIds = @event.OrderedProducts.Keys.ToList();
+        var resultSet = await dbContext.Products
+            .Where(p => productIds.Contains(p.ProductId))
+            .ToListAsync(request.HttpContext.RequestAborted);
+
+        decimal totalPrice = 0;
+        foreach (var product in @event.OrderedProducts)
         {
-            var productIds = @event.OrderedProducts.Keys.ToList();
-            var resultSet = await dbContext.Products
-                .Where(p => productIds.Contains(p.ProductId))
-                .ToListAsync(request.HttpContext.RequestAborted);
+            var matchingProduct = resultSet.Single(p => p.ProductId == product.Key);
+            product.Value.Price = matchingProduct.Price;
+            product.Value.Discount = matchingProduct.Discount;
 
-            decimal totalPrice = 0;
-            foreach (var product in @event.OrderedProducts)
-            {
-                var matchingProduct = resultSet.Single(p => p.ProductId == product.Key);
-                product.Value.Price = matchingProduct.Price;
-                product.Value.Discount = matchingProduct.Discount;
+            totalPrice += matchingProduct.EffectivePrice() * (int)product.Value.Quantity;
+        }
 
-                totalPrice += matchingProduct.EffectivePrice() * (int)product.Value.Quantity;
-            }
-
-            var vm = request.GetComposedResponseModel();
-            vm.TotalCartPrice = totalPrice;
-        });
+        var vm = request.GetComposedResponseModel();
+        vm.TotalCartPrice = totalPrice;
     }
 }

--- a/src/Finance.ServiceComposition/Products/ProductLoadedSubscriber.cs
+++ b/src/Finance.ServiceComposition/Products/ProductLoadedSubscriber.cs
@@ -1,23 +1,19 @@
 using Catalog.ServiceComposition.Events;
 using Finance.Data;
-using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using ServiceComposer.AspNetCore;
 
 namespace Finance.ServiceComposition.Products;
 
-public class ProductLoadedSubscriber(FinanceDbContext dbContext) : ICompositionEventsSubscriber
+public class ProductLoadedSubscriber(FinanceDbContext dbContext) : ICompositionEventsHandler<ProductLoaded>
 {
-    [HttpGet("/product/{productId}")]
-    public void Subscribe(ICompositionEventsPublisher publisher)
+    public async Task Handle(ProductLoaded @event, HttpRequest request)
     {
-        publisher.Subscribe<ProductLoaded>(async (@event, request) =>
-        {
-            var product = await dbContext.Products
-                .SingleAsync(s => s.ProductId == @event.ProductId, request.HttpContext.RequestAborted);
+        var product = await dbContext.Products
+            .SingleAsync(s => s.ProductId == @event.ProductId, request.HttpContext.RequestAborted);
 
-            @event.Product.Price = product.Price;
-            @event.Product.Discount = product.Discount;
-        });
+        @event.Product.Price = product.Price;
+        @event.Product.Discount = product.Discount;
     }
 }

--- a/src/Finance.ServiceComposition/Products/ProductsLoadedSubscriber.cs
+++ b/src/Finance.ServiceComposition/Products/ProductsLoadedSubscriber.cs
@@ -1,30 +1,25 @@
 using Catalog.ServiceComposition.Events;
 using Finance.Data;
-using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using ServiceComposer.AspNetCore;
 
 namespace Finance.ServiceComposition.Products;
 
-class ProductsLoadedSubscriber(FinanceDbContext dbContext) : ICompositionEventsSubscriber
+class ProductsLoadedSubscriber(FinanceDbContext dbContext) : ICompositionEventsHandler<ProductsLoaded>
 {
-    [HttpGet("/products")]
-    [HttpGet("/email/summary/{orderId}")]
-    public void Subscribe(ICompositionEventsPublisher publisher)
+    public async Task Handle(ProductsLoaded @event, HttpRequest request)
     {
-        publisher.Subscribe<ProductsLoaded>(async (@event, request) =>
-        {
-            var productIds = @event.Products.Keys.ToList();
-            var resultSet = await dbContext.Products
-                .Where(s => productIds.Contains(s.ProductId))
-                .ToListAsync(request.HttpContext.RequestAborted);
+        var productIds = @event.Products.Keys.ToList();
+        var resultSet = await dbContext.Products
+            .Where(s => productIds.Contains(s.ProductId))
+            .ToListAsync(request.HttpContext.RequestAborted);
 
-            foreach (var product in @event.Products)
-            {
-                var matchingProduct = resultSet.Single(s => s.ProductId == product.Key);
-                product.Value.Price = matchingProduct.Price;
-                product.Value.Discount = matchingProduct.Discount;
-            }
-        });
+        foreach (var product in @event.Products)
+        {
+            var matchingProduct = resultSet.Single(s => s.ProductId == product.Key);
+            product.Value.Price = matchingProduct.Price;
+            product.Value.Discount = matchingProduct.Discount;
+        }
     }
 }

--- a/src/Finance.ServiceComposition/Workflow/BillingAddressForm.cs
+++ b/src/Finance.ServiceComposition/Workflow/BillingAddressForm.cs
@@ -1,0 +1,11 @@
+namespace Finance.ServiceComposition.Workflow;
+
+// Wire shape of the POST /buy/address/{orderId} body that Finance
+// listens to. The frontend wraps the address in a billingAddress
+// envelope: { billingAddress: { fullName, street, ... } }. The
+// envelope exists only for the wire; internally we hand the
+// BillingAddressData straight into BillingAddressSlice.
+public class BillingAddressForm
+{
+    public BillingAddressData BillingAddress { get; set; } = null!;
+}

--- a/src/Finance.ServiceComposition/Workflow/CartItemForm.cs
+++ b/src/Finance.ServiceComposition/Workflow/CartItemForm.cs
@@ -1,0 +1,11 @@
+namespace Finance.ServiceComposition.Workflow;
+
+// Finance's view of one line item in the POST /cart/{orderId} JSON
+// array. Same shape as Catalog's CartItemForm but kept per-boundary
+// because each ServiceComposition project owns its own slice and its
+// own wire types.
+public class CartItemForm
+{
+    public Guid ProductId { get; set; }
+    public int Quantity { get; set; }
+}

--- a/src/Finance.ServiceComposition/Workflow/DeliveryOptionForm.cs
+++ b/src/Finance.ServiceComposition/Workflow/DeliveryOptionForm.cs
@@ -1,0 +1,10 @@
+namespace Finance.ServiceComposition.Workflow;
+
+// Wire shape of the POST /buy/shipping/{orderId} body for the Finance
+// composer. The frontend posts { deliveryOptionId } when the user
+// picks a delivery option on the shipping screen. Shipping has its
+// own copy of this form for its own composer/slice pair.
+public class DeliveryOptionForm
+{
+    public Guid DeliveryOptionId { get; set; }
+}

--- a/src/Marketing.ServiceComposition/Marketing.ServiceComposition.csproj
+++ b/src/Marketing.ServiceComposition/Marketing.ServiceComposition.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
       <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
-      <PackageReference Include="ServiceComposer.AspNetCore" Version="2.1.0" />
+      <PackageReference Include="ServiceComposer.AspNetCore" Version="5.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Marketing.ServiceComposition/Products/ProductCandidatesAvailableSubscriber.cs
+++ b/src/Marketing.ServiceComposition/Products/ProductCandidatesAvailableSubscriber.cs
@@ -1,6 +1,6 @@
 using Catalog.ServiceComposition.Events;
 using Marketing.Data;
-using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using ServiceComposer.AspNetCore;
 
@@ -10,38 +10,34 @@ namespace Marketing.ServiceComposition.Products;
 // the result back into the event. Catalog never names a Marketing sort
 // dimension; this subscriber reads ?sort= straight off the request and
 // owns the vocabulary end to end.
-class ProductCandidatesAvailableSubscriber(MarketingDbContext dbContext) : ICompositionEventsSubscriber
+class ProductCandidatesAvailableSubscriber(MarketingDbContext dbContext) : ICompositionEventsHandler<ProductCandidatesAvailable>
 {
-    [HttpGet("/products")]
-    public void Subscribe(ICompositionEventsPublisher publisher)
+    public async Task Handle(ProductCandidatesAvailable @event, HttpRequest request)
     {
-        publisher.Subscribe<ProductCandidatesAvailable>(async (@event, request) =>
+        if (@event.CandidateIds.Count == 0) return;
+
+        if (!request.Query.TryGetValue("sort", out var values) || values.Count == 0)
+            return;
+
+        var ct = request.HttpContext.RequestAborted;
+        var ids = @event.CandidateIds.ToList();
+        var query = dbContext.Products.Where(p => ids.Contains(p.ProductId));
+
+        // ThenBy(ProductId) is a stable tiebreaker so paginated rank order is reproducible across requests.
+        query = values[0]?.ToLowerInvariant() switch
         {
-            if (@event.CandidateIds.Count == 0) return;
+            "rating" => query.OrderByDescending(p => p.Rating).ThenBy(p => p.ProductId),
+            "ordercount" => query.OrderByDescending(p => p.OrderCount).ThenBy(p => p.ProductId),
+            "trending" => query.OrderByDescending(p => p.Trending).ThenBy(p => p.ProductId),
+            _ => null
+        };
 
-            if (!request.Query.TryGetValue("sort", out var values) || values.Count == 0)
-                return;
+        if (query is null) return;
 
-            var ct = request.HttpContext.RequestAborted;
-            var ids = @event.CandidateIds.ToList();
-            var query = dbContext.Products.Where(p => ids.Contains(p.ProductId));
-
-            // ThenBy(ProductId) is a stable tiebreaker so paginated rank order is reproducible across requests.
-            query = values[0]?.ToLowerInvariant() switch
-            {
-                "rating" => query.OrderByDescending(p => p.Rating).ThenBy(p => p.ProductId),
-                "ordercount" => query.OrderByDescending(p => p.OrderCount).ThenBy(p => p.ProductId),
-                "trending" => query.OrderByDescending(p => p.Trending).ThenBy(p => p.ProductId),
-                _ => null
-            };
-
-            if (query is null) return;
-
-            @event.OrderedIds = await query
-                .Skip((@event.Page - 1) * @event.Size)
-                .Take(@event.Size)
-                .Select(p => p.ProductId)
-                .ToListAsync(ct);
-        });
+        @event.OrderedIds = await query
+            .Skip((@event.Page - 1) * @event.Size)
+            .Take(@event.Size)
+            .Select(p => p.ProductId)
+            .ToListAsync(ct);
     }
 }

--- a/src/Marketing.ServiceComposition/Products/ProductLoadedSubscriber.cs
+++ b/src/Marketing.ServiceComposition/Products/ProductLoadedSubscriber.cs
@@ -1,25 +1,21 @@
 using Catalog.ServiceComposition.Events;
 using Marketing.Data;
-using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using ServiceComposer.AspNetCore;
 
 namespace Marketing.ServiceComposition.Products;
 
-class ProductLoadedSubscriber(MarketingDbContext dbContext) : ICompositionEventsSubscriber
+class ProductLoadedSubscriber(MarketingDbContext dbContext) : ICompositionEventsHandler<ProductLoaded>
 {
-    [HttpGet("/product/{productId}")]
-    public void Subscribe(ICompositionEventsPublisher publisher)
+    public async Task Handle(ProductLoaded @event, HttpRequest request)
     {
-        publisher.Subscribe<ProductLoaded>(async (@event, request) =>
-        {
-            var product = await dbContext.Products
-                .SingleAsync(s => s.ProductId == @event.ProductId, request.HttpContext.RequestAborted);
+        var product = await dbContext.Products
+            .SingleAsync(s => s.ProductId == @event.ProductId, request.HttpContext.RequestAborted);
 
-            @event.Product.Rating = product.Rating;
-            @event.Product.RatingCount = product.RatingCount;
-            @event.Product.OrderCount = product.OrderCount;
-            @event.Product.Trending = product.Trending;
-        });
+        @event.Product.Rating = product.Rating;
+        @event.Product.RatingCount = product.RatingCount;
+        @event.Product.OrderCount = product.OrderCount;
+        @event.Product.Trending = product.Trending;
     }
 }

--- a/src/Marketing.ServiceComposition/Products/ProductsLoadedSubscriber.cs
+++ b/src/Marketing.ServiceComposition/Products/ProductsLoadedSubscriber.cs
@@ -1,31 +1,27 @@
 using Catalog.ServiceComposition.Events;
 using Marketing.Data;
-using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using ServiceComposer.AspNetCore;
 
 namespace Marketing.ServiceComposition.Products;
 
-class ProductsLoadedSubscriber(MarketingDbContext dbContext) : ICompositionEventsSubscriber
+class ProductsLoadedSubscriber(MarketingDbContext dbContext) : ICompositionEventsHandler<ProductsLoaded>
 {
-    [HttpGet("/products")]
-    public void Subscribe(ICompositionEventsPublisher publisher)
+    public async Task Handle(ProductsLoaded @event, HttpRequest request)
     {
-        publisher.Subscribe<ProductsLoaded>(async (@event, request) =>
-        {
-            var productIds = @event.Products.Keys.ToList();
-            var resultSet = await dbContext.Products
-                .Where(s => productIds.Contains(s.ProductId))
-                .ToListAsync(request.HttpContext.RequestAborted);
+        var productIds = @event.Products.Keys.ToList();
+        var resultSet = await dbContext.Products
+            .Where(s => productIds.Contains(s.ProductId))
+            .ToListAsync(request.HttpContext.RequestAborted);
 
-            foreach (var product in @event.Products)
-            {
-                var matchingProduct = resultSet.Single(s => s.ProductId == product.Key);
-                product.Value.Rating = matchingProduct.Rating;
-                product.Value.RatingCount = matchingProduct.RatingCount;
-                product.Value.OrderCount = matchingProduct.OrderCount;
-                product.Value.Trending = matchingProduct.Trending;
-            }
-        });
+        foreach (var product in @event.Products)
+        {
+            var matchingProduct = resultSet.Single(s => s.ProductId == product.Key);
+            product.Value.Rating = matchingProduct.Rating;
+            product.Value.RatingCount = matchingProduct.RatingCount;
+            product.Value.OrderCount = matchingProduct.OrderCount;
+            product.Value.Trending = matchingProduct.Trending;
+        }
     }
 }

--- a/src/OmNomNom.BackOffice/OmNomNom.BackOffice.csproj
+++ b/src/OmNomNom.BackOffice/OmNomNom.BackOffice.csproj
@@ -8,13 +8,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <!-- Same NU1107 break as CompositionGateway: ServiceComposer caps
-           DependencyModel below 9, EF Core 10 (transitively via Catalog.Data)
-           wants 10. Pin the higher version explicitly. -->
-      <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.0" />
+      <!-- Newtonsoft.Json drives the dynamic Razor model in OrderShippedHandler / EmailContent.cshtml.
+           It used to ride in transitively via ServiceComposer.AspNetCore 2.x; 4.x+ switched to
+           System.Text.Json, so we now reference it explicitly. -->
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
       <PackageReference Include="NServiceBus" Version="10.1.4" />
       <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.0.1" />
-      <PackageReference Include="ServiceComposer.AspNetCore" Version="2.1.0" />
+      <PackageReference Include="ServiceComposer.AspNetCore" Version="5.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/OmNomNom.BackOffice/Program.cs
+++ b/src/OmNomNom.BackOffice/Program.cs
@@ -6,6 +6,7 @@ using ServiceComposer.AspNetCore;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddRouting();
+builder.Services.AddHttpContextAccessor();
 builder.Services.AddControllersWithViews();
 builder.Services.AddViewModelComposition(options =>
 {

--- a/src/PaymentInfo.ServiceComposition/Checkout/CreditCardComposer.cs
+++ b/src/PaymentInfo.ServiceComposition/Checkout/CreditCardComposer.cs
@@ -7,13 +7,17 @@ using ServiceComposer.AspNetCore;
 
 namespace PaymentInfo.ServiceComposition.Checkout;
 
-public class CreditCardComposer(PaymentInfoDbContext dbContext) : ICompositionRequestsHandler
+[CompositionHandler]
+public class CreditCardComposer(PaymentInfoDbContext dbContext, IHttpContextAccessor http)
 {
     [HttpGet("/buy/creditcard/{customerId}")]
-    public async Task Handle(HttpRequest request)
+    public async Task Handle(Guid customerId)
     {
+        var request = http.HttpContext!.Request;
         var vm = request.GetComposedResponseModel();
-        var customerId = Guid.Parse("01093176-1308-493a-8f67-da5d278e2375");
+        // TODO: route binds the customerId, but the real lookup is still
+        // hardcoded until authentication is wired in.
+        customerId = Guid.Parse("01093176-1308-493a-8f67-da5d278e2375");
 
         var creditCards = await dbContext.CreditCards
             .Where(s => s.CustomerId == customerId)

--- a/src/PaymentInfo.ServiceComposition/Checkout/PaymentComposer.cs
+++ b/src/PaymentInfo.ServiceComposition/Checkout/PaymentComposer.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using PaymentInfo.Data;
 using PaymentInfo.ServiceComposition.Workflow;
@@ -9,14 +8,14 @@ using WorkflowComposer;
 
 namespace PaymentInfo.ServiceComposition.Checkout;
 
-public class PaymentComposer(PaymentInfoDbContext dbContext, IWorkflowStore workflow) : ICompositionRequestsHandler
+[CompositionHandler]
+public class PaymentComposer(PaymentInfoDbContext dbContext, IWorkflowStore workflow, IHttpContextAccessor http)
 {
     [HttpGet("/buy/payment/{orderId}")]
-    public async Task Handle(HttpRequest request)
+    public async Task Handle(Guid orderId)
     {
+        var request = http.HttpContext!.Request;
         var vm = request.GetComposedResponseModel();
-        var orderIdString = (string)request.HttpContext.GetRouteData().Values["orderId"]!;
-        var orderId = Guid.Parse(orderIdString);
         var ct = request.HttpContext.RequestAborted;
 
         // The slice is the user's just-selected card (synchronously

--- a/src/PaymentInfo.ServiceComposition/Checkout/PaymentSubmitComposer.cs
+++ b/src/PaymentInfo.ServiceComposition/Checkout/PaymentSubmitComposer.cs
@@ -6,25 +6,19 @@ using WorkflowComposer;
 
 namespace PaymentInfo.ServiceComposition.Checkout;
 
-public class PaymentSubmitComposer(IWorkflowStore workflow) : ICompositionRequestsHandler
+[CompositionHandler]
+public class PaymentSubmitComposer(IWorkflowStore workflow, IHttpContextAccessor http)
 {
     [HttpPost("/buy/payment/{orderId}")]
-    public async Task Handle(HttpRequest request)
+    public async Task Handle(Guid orderId, [FromBody] PaymentBody body)
     {
-        var submitted = await request.Bind<CreditCard>();
-        var ct = request.HttpContext.RequestAborted;
+        var ct = http.HttpContext!.RequestAborted;
 
-        var slice = new PaymentSlice(submitted.Body.CreditCardId);
-        await workflow.Write(submitted.OrderId, PaymentWorkflowSlice.Key, slice, ct);
+        var slice = new PaymentSlice(body.CreditCardId);
+        await workflow.Write(orderId, PaymentWorkflowSlice.Key, slice, ct);
     }
 
-    class CreditCard
-    {
-        [FromRoute] public Guid OrderId { get; set; }
-        [FromBody] public PaymentBody Body { get; set; } = null!;
-    }
-
-    class PaymentBody
+    public class PaymentBody
     {
         public Guid CreditCardId { get; set; }
     }

--- a/src/PaymentInfo.ServiceComposition/Checkout/PaymentSubmitComposer.cs
+++ b/src/PaymentInfo.ServiceComposition/Checkout/PaymentSubmitComposer.cs
@@ -10,16 +10,11 @@ namespace PaymentInfo.ServiceComposition.Checkout;
 public class PaymentSubmitComposer(IWorkflowStore workflow, IHttpContextAccessor http)
 {
     [HttpPost("/buy/payment/{orderId}")]
-    public async Task Handle(Guid orderId, [FromBody] PaymentBody body)
+    public async Task Handle(Guid orderId, [FromBody] PaymentForm form)
     {
         var ct = http.HttpContext!.RequestAborted;
 
-        var slice = new PaymentSlice(body.CreditCardId);
+        var slice = new PaymentSlice(form.CreditCardId);
         await workflow.Write(orderId, PaymentWorkflowSlice.Key, slice, ct);
-    }
-
-    public class PaymentBody
-    {
-        public Guid CreditCardId { get; set; }
     }
 }

--- a/src/PaymentInfo.ServiceComposition/Checkout/SummaryComposer.cs
+++ b/src/PaymentInfo.ServiceComposition/Checkout/SummaryComposer.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using PaymentInfo.Data;
 using PaymentInfo.ServiceComposition.Workflow;
@@ -9,14 +8,13 @@ using WorkflowComposer;
 
 namespace PaymentInfo.ServiceComposition.Checkout;
 
-public class SummaryComposer(PaymentInfoDbContext dbContext, IWorkflowStore workflow) : ICompositionRequestsHandler
+[CompositionHandler]
+public class SummaryComposer(PaymentInfoDbContext dbContext, IWorkflowStore workflow, IHttpContextAccessor http)
 {
     [HttpGet("/buy/summary/{orderId}")]
-    public async Task Handle(HttpRequest request)
+    public async Task Handle(Guid orderId)
     {
-        var orderIdString = (string)request.HttpContext.GetRouteData().Values["orderId"]!;
-        var orderId = Guid.Parse(orderIdString);
-        var ct = request.HttpContext.RequestAborted;
+        var ct = http.HttpContext!.RequestAborted;
 
         var row = await (
             from o in dbContext.Orders
@@ -40,7 +38,7 @@ public class SummaryComposer(PaymentInfoDbContext dbContext, IWorkflowStore work
                     .FirstOrDefaultAsync(s => s.CreditCardId == slice.CreditCardId, ct);
         }
 
-        var vm = request.GetComposedResponseModel();
+        var vm = http.HttpContext!.Request.GetComposedResponseModel();
         vm.CreditCardLastDigits = creditCard?.LastDigits;
         vm.CreditCardType = creditCard?.CardType;
     }

--- a/src/PaymentInfo.ServiceComposition/PaymentInfo.ServiceComposition.csproj
+++ b/src/PaymentInfo.ServiceComposition/PaymentInfo.ServiceComposition.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
-      <PackageReference Include="ServiceComposer.AspNetCore" Version="2.1.0" />
+      <PackageReference Include="ServiceComposer.AspNetCore" Version="5.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/PaymentInfo.ServiceComposition/Workflow/PaymentForm.cs
+++ b/src/PaymentInfo.ServiceComposition/Workflow/PaymentForm.cs
@@ -1,0 +1,10 @@
+namespace PaymentInfo.ServiceComposition.Workflow;
+
+// Wire shape of the POST /buy/payment/{orderId} body. The frontend
+// posts { creditCardId } when the user picks a stored card on the
+// payment screen. The CustomerId is environmental and is filled in
+// server-side by PaymentWorkflowSlice.BuildSubmitCommand.
+public class PaymentForm
+{
+    public Guid CreditCardId { get; set; }
+}

--- a/src/Shipping.ServiceComposition/Checkout/AddressComposer.cs
+++ b/src/Shipping.ServiceComposition/Checkout/AddressComposer.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
 using ServiceComposer.AspNetCore;
 using Shipping.Data.Models;
 using Shipping.ServiceComposition.Workflow;
@@ -8,14 +7,14 @@ using WorkflowComposer;
 
 namespace Shipping.ServiceComposition.Checkout;
 
-public class AddressComposer(IWorkflowStore workflow) : ICompositionRequestsHandler
+[CompositionHandler]
+public class AddressComposer(IWorkflowStore workflow, IHttpContextAccessor http)
 {
     [HttpGet("/buy/address/{orderId}")]
-    public async Task Handle(HttpRequest request)
+    public async Task Handle(Guid orderId)
     {
+        var request = http.HttpContext!.Request;
         var vm = request.GetComposedResponseModel();
-        var orderIdString = (string)request.HttpContext.GetRouteData().Values["orderId"]!;
-        var orderId = Guid.Parse(orderIdString);
         var ct = request.HttpContext.RequestAborted;
 
         // Slice holds the user's just-entered address; if empty, fall

--- a/src/Shipping.ServiceComposition/Checkout/AddressSubmitComposer.cs
+++ b/src/Shipping.ServiceComposition/Checkout/AddressSubmitComposer.cs
@@ -7,31 +7,25 @@ using WorkflowComposer;
 
 namespace Shipping.ServiceComposition.Checkout;
 
-public class AddressSubmitComposer(IWorkflowStore workflow) : ICompositionRequestsHandler
+[CompositionHandler]
+public class AddressSubmitComposer(IWorkflowStore workflow, IHttpContextAccessor http)
 {
     [HttpPost("/buy/address/{orderId}")]
-    public async Task Handle(HttpRequest request)
+    public async Task Handle(Guid orderId, [FromBody] OrderAddress details)
     {
-        var submitted = await request.Bind<OrderAddressDetails>();
-        var ct = request.HttpContext.RequestAborted;
+        var ct = http.HttpContext!.RequestAborted;
 
         var slice = new ShippingAddressSlice(
-            submitted.Details.ShippingAddress.FullName,
-            submitted.Details.ShippingAddress.Street,
-            submitted.Details.ShippingAddress.ZipCode,
-            submitted.Details.ShippingAddress.Town,
-            submitted.Details.ShippingAddress.Country);
-        await workflow.Write(submitted.OrderId, ShippingAddressWorkflowSlice.Key, slice, ct);
+            details.ShippingAddress.FullName,
+            details.ShippingAddress.Street,
+            details.ShippingAddress.ZipCode,
+            details.ShippingAddress.Town,
+            details.ShippingAddress.Country);
+        await workflow.Write(orderId, ShippingAddressWorkflowSlice.Key, slice, ct);
     }
 
-    class OrderAddressDetails
+    public class OrderAddress
     {
-        [FromRoute] public Guid OrderId { get; set; }
-        [FromBody] public OrderAddress Details { get; set; } = null!;
-
-        public class OrderAddress
-        {
-            public Address ShippingAddress { get; set; } = null!;
-        }
+        public Address ShippingAddress { get; set; } = null!;
     }
 }

--- a/src/Shipping.ServiceComposition/Checkout/AddressSubmitComposer.cs
+++ b/src/Shipping.ServiceComposition/Checkout/AddressSubmitComposer.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using ServiceComposer.AspNetCore;
-using Shipping.Data.Models;
 using Shipping.ServiceComposition.Workflow;
 using WorkflowComposer;
 
@@ -11,21 +10,16 @@ namespace Shipping.ServiceComposition.Checkout;
 public class AddressSubmitComposer(IWorkflowStore workflow, IHttpContextAccessor http)
 {
     [HttpPost("/buy/address/{orderId}")]
-    public async Task Handle(Guid orderId, [FromBody] OrderAddress details)
+    public async Task Handle(Guid orderId, [FromBody] ShippingAddressForm form)
     {
         var ct = http.HttpContext!.RequestAborted;
 
         var slice = new ShippingAddressSlice(
-            details.ShippingAddress.FullName,
-            details.ShippingAddress.Street,
-            details.ShippingAddress.ZipCode,
-            details.ShippingAddress.Town,
-            details.ShippingAddress.Country);
+            form.ShippingAddress.FullName,
+            form.ShippingAddress.Street,
+            form.ShippingAddress.ZipCode,
+            form.ShippingAddress.Town,
+            form.ShippingAddress.Country);
         await workflow.Write(orderId, ShippingAddressWorkflowSlice.Key, slice, ct);
-    }
-
-    public class OrderAddress
-    {
-        public Address ShippingAddress { get; set; } = null!;
     }
 }

--- a/src/Shipping.ServiceComposition/Checkout/DeliveryOptionSubmitComposer.cs
+++ b/src/Shipping.ServiceComposition/Checkout/DeliveryOptionSubmitComposer.cs
@@ -10,16 +10,11 @@ namespace Shipping.ServiceComposition.Checkout;
 public class DeliveryOptionSubmitComposer(IWorkflowStore workflow, IHttpContextAccessor http)
 {
     [HttpPost("/buy/shipping/{orderId}")]
-    public async Task Handle(Guid orderId, [FromBody] SelectedDeliveryOption body)
+    public async Task Handle(Guid orderId, [FromBody] DeliveryOptionForm form)
     {
         var ct = http.HttpContext!.RequestAborted;
 
-        var slice = new DeliveryOptionSlice(body.DeliveryOptionId);
+        var slice = new DeliveryOptionSlice(form.DeliveryOptionId);
         await workflow.Write(orderId, DeliveryOptionWorkflowSlice.Key, slice, ct);
-    }
-
-    public class SelectedDeliveryOption
-    {
-        public Guid DeliveryOptionId { get; set; }
     }
 }

--- a/src/Shipping.ServiceComposition/Checkout/DeliveryOptionSubmitComposer.cs
+++ b/src/Shipping.ServiceComposition/Checkout/DeliveryOptionSubmitComposer.cs
@@ -6,25 +6,19 @@ using WorkflowComposer;
 
 namespace Shipping.ServiceComposition.Checkout;
 
-public class DeliveryOptionSubmitComposer(IWorkflowStore workflow) : ICompositionRequestsHandler
+[CompositionHandler]
+public class DeliveryOptionSubmitComposer(IWorkflowStore workflow, IHttpContextAccessor http)
 {
     [HttpPost("/buy/shipping/{orderId}")]
-    public async Task Handle(HttpRequest request)
+    public async Task Handle(Guid orderId, [FromBody] SelectedDeliveryOption body)
     {
-        var submitted = await request.Bind<SelectedDeliveryOption>();
-        var ct = request.HttpContext.RequestAborted;
+        var ct = http.HttpContext!.RequestAborted;
 
-        var slice = new DeliveryOptionSlice(submitted.Body.DeliveryOptionId);
-        await workflow.Write(submitted.OrderId, DeliveryOptionWorkflowSlice.Key, slice, ct);
+        var slice = new DeliveryOptionSlice(body.DeliveryOptionId);
+        await workflow.Write(orderId, DeliveryOptionWorkflowSlice.Key, slice, ct);
     }
 
-    class SelectedDeliveryOption
-    {
-        [FromRoute] public Guid OrderId { get; set; }
-        [FromBody] public BodyModel Body { get; set; } = null!;
-    }
-
-    class BodyModel
+    public class SelectedDeliveryOption
     {
         public Guid DeliveryOptionId { get; set; }
     }

--- a/src/Shipping.ServiceComposition/Checkout/DeliveryOptionsComposer.cs
+++ b/src/Shipping.ServiceComposition/Checkout/DeliveryOptionsComposer.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using ServiceComposer.AspNetCore;
 using Shipping.Data;
@@ -11,13 +10,13 @@ using WorkflowComposer;
 
 namespace Shipping.ServiceComposition.Checkout;
 
-public class DeliveryOptionsComposer(ShippingDbContext dbContext, IWorkflowStore workflow) : ICompositionRequestsHandler
+[CompositionHandler]
+public class DeliveryOptionsComposer(ShippingDbContext dbContext, IWorkflowStore workflow, IHttpContextAccessor http)
 {
     [HttpGet("/buy/shipping/{orderId}")]
-    public async Task Handle(HttpRequest request)
+    public async Task Handle(Guid orderId)
     {
-        var orderIdString = (string)request.HttpContext.GetRouteData().Values["orderId"]!;
-        var orderId = Guid.Parse(orderIdString);
+        var request = http.HttpContext!.Request;
         var ct = request.HttpContext.RequestAborted;
 
         // Get all available delivery options

--- a/src/Shipping.ServiceComposition/Checkout/SummaryComposer.cs
+++ b/src/Shipping.ServiceComposition/Checkout/SummaryComposer.cs
@@ -1,7 +1,6 @@
 using System.Dynamic;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using ServiceComposer.AspNetCore;
 using Shipping.Data;
@@ -11,16 +10,22 @@ using WorkflowComposer;
 
 namespace Shipping.ServiceComposition.Checkout;
 
-public class SummaryComposer(ShippingDbContext dbContext, IWorkflowStore workflow) : ICompositionRequestsHandler
+[CompositionHandler]
+public class SummaryComposer(ShippingDbContext dbContext, IWorkflowStore workflow, IHttpContextAccessor http)
 {
+    // ServiceComposer 5.x allows only one Http* attribute per method;
+    // payment and summary screens get their own entry points that share
+    // LoadAsync. Both screens need the same shipping summary slice.
     [HttpGet("/buy/payment/{orderId}")]
-    [HttpGet("/buy/summary/{orderId}")]
-    public async Task Handle(HttpRequest request)
-    {
-        var vm = request.GetComposedResponseModel();
+    public Task HandlePayment(Guid orderId) => LoadAsync(orderId);
 
-        var orderIdString = (string)request.HttpContext.GetRouteData().Values["orderId"]!;
-        var orderId = Guid.Parse(orderIdString);
+    [HttpGet("/buy/summary/{orderId}")]
+    public Task HandleSummary(Guid orderId) => LoadAsync(orderId);
+
+    async Task LoadAsync(Guid orderId)
+    {
+        var request = http.HttpContext!.Request;
+        var vm = request.GetComposedResponseModel();
         var ct = request.HttpContext.RequestAborted;
 
         // DeliveryOptionSubmitHandler writes the chosen DeliveryOptionId

--- a/src/Shipping.ServiceComposition/DeliveryOptions/Mapper.cs
+++ b/src/Shipping.ServiceComposition/DeliveryOptions/Mapper.cs
@@ -1,10 +1,9 @@
 using System.Dynamic;
-using Microsoft.Extensions.Options;
 using Shipping.Data.Models;
 
 namespace Shipping.ServiceComposition.DeliveryOptions;
 
-public class Mapper
+public static class Mapper
 {
     public static IDictionary<Guid, dynamic> MapToDictionary(IEnumerable<DeliveryOption> deliveryOptions)
     {
@@ -14,7 +13,7 @@ public class Mapper
         {
             deliveryOptionsViewModel[option.DeliveryOptionId] = MapToViewModel(option);
         }
-        
+
         return deliveryOptionsViewModel;
     }
 
@@ -24,7 +23,6 @@ public class Mapper
         vm.DeliveryOptionId = option.DeliveryOptionId;
         vm.Name = option.Name;
         vm.Description = option.Description;
-
         return vm;
     }
 }

--- a/src/Shipping.ServiceComposition/Email/DeliveryOptionSubscriber.cs
+++ b/src/Shipping.ServiceComposition/Email/DeliveryOptionSubscriber.cs
@@ -1,24 +1,19 @@
 using Finance.ServiceComposition.Events;
-using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using ServiceComposer.AspNetCore;
 using Shipping.Data;
-using Shipping.ServiceComposition.Events;
 
 namespace Shipping.ServiceComposition.Email;
 
-public class DeliveryOptionLoadedSubscriber(ShippingDbContext dbContext) : ICompositionEventsSubscriber
+public class DeliveryOptionLoadedSubscriber(ShippingDbContext dbContext) : ICompositionEventsHandler<DeliveryOptionLoaded>
 {
-    [HttpGet("/email/summary/{orderId}")]
-    public void Subscribe(ICompositionEventsPublisher publisher)
+    public async Task Handle(DeliveryOptionLoaded @event, HttpRequest request)
     {
-        publisher.Subscribe<DeliveryOptionLoaded>(async (@event, request) =>
-        {
-            var result = await dbContext.DeliveryOptions
-                .SingleAsync(s => s.DeliveryOptionId == @event.DeliveryOptionId, request.HttpContext.RequestAborted);
+        var result = await dbContext.DeliveryOptions
+            .SingleAsync(s => s.DeliveryOptionId == @event.DeliveryOptionId, request.HttpContext.RequestAborted);
 
-            @event.DeliveryOption.Name = result.Name;
-            @event.DeliveryOption.Description = result.Description;
-        });
+        @event.DeliveryOption.Name = result.Name;
+        @event.DeliveryOption.Description = result.Description;
     }
 }

--- a/src/Shipping.ServiceComposition/Shipping.ServiceComposition.csproj
+++ b/src/Shipping.ServiceComposition/Shipping.ServiceComposition.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
-      <PackageReference Include="ServiceComposer.AspNetCore" Version="2.1.0" />
+      <PackageReference Include="ServiceComposer.AspNetCore" Version="5.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Shipping.ServiceComposition/Workflow/DeliveryOptionForm.cs
+++ b/src/Shipping.ServiceComposition/Workflow/DeliveryOptionForm.cs
@@ -1,0 +1,10 @@
+namespace Shipping.ServiceComposition.Workflow;
+
+// Wire shape of the POST /buy/shipping/{orderId} body that Shipping
+// listens to. Same shape as Finance's DeliveryOptionForm but kept
+// per-boundary because each ServiceComposition project owns its own
+// slice and its own wire types.
+public class DeliveryOptionForm
+{
+    public Guid DeliveryOptionId { get; set; }
+}

--- a/src/Shipping.ServiceComposition/Workflow/ShippingAddressForm.cs
+++ b/src/Shipping.ServiceComposition/Workflow/ShippingAddressForm.cs
@@ -1,0 +1,13 @@
+using Shipping.Data.Models;
+
+namespace Shipping.ServiceComposition.Workflow;
+
+// Wire shape of the POST /buy/address/{orderId} body that Shipping
+// listens to. The frontend wraps the address in a shippingAddress
+// envelope: { shippingAddress: { fullName, street, ... } }. The
+// envelope only exists for the wire; AddressSubmitComposer copies
+// the fields into ShippingAddressSlice.
+public class ShippingAddressForm
+{
+    public Address ShippingAddress { get; set; } = null!;
+}


### PR DESCRIPTION
## Summary

- Upgrade `ServiceComposer.AspNetCore` from 2.1.0 to 5.2.0 across every `*.ServiceComposition` project plus the gateway and back-office. Drops the `Microsoft.Extensions.DependencyModel` and `Mvc.NewtonsoftJson` pins (workarounds for 2.1.0 capping DependencyModel below 9). Adds an explicit `Newtonsoft.Json` reference to `OmNomNom.BackOffice` for the email Razor view.
- Migrate all 26 request composers from `ICompositionRequestsHandler` to the contract-less `[CompositionHandler]` syntax. Method parameters now bind via standard ASP.NET attributes (route ids implicit, bodies via `[FromBody]`, query strings via `[FromQuery]`).
- Migrate all 12 event subscribers from `ICompositionEventsSubscriber` to `ICompositionEventsHandler<TEvent>`. The route attribute on `Subscribe` wasn't gating anything useful - every subscriber's body was invariant across the routes its event was raised from.
- Adopt declarative model binding throughout: a typed `ProductsQuery` drives `/products`, every POST endpoint has a typed `*Form` body class, and those form types now live alongside their slices under each project's `Workflow/` folder.
- Normalise the Mapper convention: every composer that builds a viewmodel goes through a `public static class Mapper` with both `MapToViewModel(...)` and `MapToDictionary(...)`.

## Caveats

- 5.2.0 has a cached-pipeline bug that captures the first request's bound arguments and replays them on subsequent requests; an upstream PR is open ([ServiceComposer#1040](https://github.com/ServiceComposer/ServiceComposer.AspNetCore/pull/1040)). Local development uses a patched fork build via an uncommitted \`NuGet.config\`. **Don't merge this branch until that PR ships in a public release and the package version refs here are bumped to it.**
- Strongly-typed viewmodels via \`IViewModelFactory\` are out of scope.
- The two \`OrderSubmitComposer\`s (POST \`/cart/{orderId}\`) still read \`request.Body\` directly rather than via \`[FromBody]\`; the 5.2 source generator can't encode \`List<T>\`/\`T[]\` in hintNames.

## Test plan

- [x] \`dotnet build src/OmNomNom.slnx\` - clean.
- [x] Full POST flow via curl: add product, commit cart, save shipping+billing address, pick delivery option, pick credit card.
- [x] GET smoke: \`/products\` (filters/page/size/sort), \`/products/facets\`, \`/cart/{id}\`, \`/buy/address|/buy/payment|/buy/summary\`. Composed responses include subscriber-contributed fields from Finance, Catalog, Marketing.
- [x] Reviewer: run the JetBrains compound \`Website + Endpoints\` and walk the full checkout end-to-end.