### PR TITLE
Auto-prune workflow slices after inactivity

### DIFF
--- a/src/WorkflowComposer.Sqlite/SqliteWorkflowStore.cs
+++ b/src/WorkflowComposer.Sqlite/SqliteWorkflowStore.cs
@@ -94,6 +94,30 @@ internal sealed class SqliteWorkflowStore(
         await session.Commit(ct);
     }
 
+    public async Task<int> DeleteInactive(TimeSpan inactivity, CancellationToken ct)
+    {
+        await EnsureTable(ct);
+
+        var cutoff = DateTimeOffset.UtcNow.Subtract(inactivity).ToString("O");
+
+        await using var connection = new SqliteConnection(options.ConnectionString);
+        await connection.OpenAsync(ct);
+
+        await using var cmd = connection.CreateCommand();
+        // Group by WorkflowId so a single fresh slice keeps the whole
+        // workflow alive; only workflows whose most recent write is
+        // older than the cutoff are dropped.
+        cmd.CommandText = $@"
+            DELETE FROM {options.TableName}
+            WHERE WorkflowId IN (
+                SELECT WorkflowId FROM {options.TableName}
+                GROUP BY WorkflowId
+                HAVING MAX(UpdatedAt) < $cutoff
+            );";
+        cmd.Parameters.AddWithValue("$cutoff", cutoff);
+        return await cmd.ExecuteNonQueryAsync(ct);
+    }
+
     async Task EnsureTable(CancellationToken ct)
     {
         if (tableEnsured) return;

--- a/src/WorkflowComposer/IWorkflowStore.cs
+++ b/src/WorkflowComposer/IWorkflowStore.cs
@@ -17,4 +17,10 @@ public interface IWorkflowStore
     // dispatch, or none. Backends with an outbox commit the workflow
     // row and the queued messages in one transaction.
     Task Submit(Guid workflowId, IReadOnlyList<object> commands, CancellationToken ct);
+
+    // Drop every slice belonging to workflows whose most recent write
+    // is older than `inactivity`. Returns the number of rows deleted
+    // for telemetry. Backends with native expiry (Redis) implement
+    // this as a no-op and lean on TTLs instead.
+    Task<int> DeleteInactive(TimeSpan inactivity, CancellationToken ct);
 }

--- a/src/WorkflowComposer/ServiceCollectionExtensions.cs
+++ b/src/WorkflowComposer/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace WorkflowComposer;
 
@@ -16,6 +17,13 @@ public static class ServiceCollectionExtensions
         // in-memory store would be fine as singleton, but matching the
         // store's lifetime avoids captive-dependency surprises.
         services.AddScoped<IWorkflowSubmitter, WorkflowSubmitter>();
+
+        // Capture the cleanup knobs so changes to `options` after this
+        // call no longer affect the running service.
+        services.AddSingleton(new WorkflowCleanupSettings(
+            options.InactivityThreshold,
+            options.CleanupInterval));
+        services.AddHostedService<WorkflowCleanupHostedService>();
 
         return services;
     }

--- a/src/WorkflowComposer/WorkflowCleanupHostedService.cs
+++ b/src/WorkflowComposer/WorkflowCleanupHostedService.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace WorkflowComposer;
+
+internal sealed class WorkflowCleanupHostedService(
+    IServiceScopeFactory scopeFactory,
+    WorkflowCleanupSettings settings,
+    ILogger<WorkflowCleanupHostedService> log) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(settings.CleanupInterval);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                if (!await timer.WaitForNextTickAsync(stoppingToken)) return;
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+
+            try
+            {
+                // IWorkflowStore is scoped (the SQLite backend depends
+                // on the per-request ITransactionalSession), so each
+                // pass gets its own scope. DeleteInactive itself
+                // doesn't touch the session.
+                using var scope = scopeFactory.CreateScope();
+                var store = scope.ServiceProvider.GetRequiredService<IWorkflowStore>();
+                var deleted = await store.DeleteInactive(settings.InactivityThreshold, stoppingToken);
+                if (deleted > 0)
+                {
+                    log.LogInformation(
+                        "Workflow cleanup removed {Deleted} slice rows older than {Threshold}.",
+                        deleted, settings.InactivityThreshold);
+                }
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                // One failed sweep shouldn't take the service down -
+                // the next tick will retry naturally.
+                log.LogError(ex, "Workflow cleanup pass failed.");
+            }
+        }
+    }
+}
+
+internal sealed record WorkflowCleanupSettings(TimeSpan InactivityThreshold, TimeSpan CleanupInterval);

--- a/src/WorkflowComposer/WorkflowComposer.csproj
+++ b/src/WorkflowComposer/WorkflowComposer.csproj
@@ -10,6 +10,8 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     </ItemGroup>
 
 </Project>

--- a/src/WorkflowComposer/WorkflowComposerOptions.cs
+++ b/src/WorkflowComposer/WorkflowComposerOptions.cs
@@ -15,6 +15,17 @@ public sealed class WorkflowComposerOptions
 
     public IServiceCollection Services { get; }
 
+    // Workflows go cold once the user walks away from the checkout
+    // page. Twenty minutes is long enough that a returning user with
+    // a back-button still finds their cart, short enough that
+    // abandoned rows don't accumulate forever.
+    public TimeSpan InactivityThreshold { get; set; } = TimeSpan.FromMinutes(20);
+
+    // How often the cleanup pass runs. Smaller than the threshold so
+    // abandoned workflows get pruned within ~one interval of crossing
+    // the line, not at some arbitrary delay after.
+    public TimeSpan CleanupInterval { get; set; } = TimeSpan.FromMinutes(5);
+
     // Discover and register every IWorkflowSlice implementation in
     // the given assemblies. Each slice is registered as a singleton
     // because it carries no per-request state.


### PR DESCRIPTION
## Summary
- Abandoned checkouts left `WorkflowSlices` rows behind forever. This adds a `DeleteInactive` contract on `IWorkflowStore` (SQL `DELETE` keyed by `MAX(UpdatedAt)` per `WorkflowId` in the SQLite backend; no-op-ready for TTL-native stores).
- Adds `WorkflowCleanupHostedService`, a `BackgroundService` that sweeps on a configurable interval using a per-tick DI scope (required because `IWorkflowStore` is scoped via its `ITransactionalSession` dependency).
- Defaults: 20 min inactivity threshold, 5 min sweep cadence, configurable via `WorkflowComposerOptions`.

## Test plan
- [x] Run the app, leave a workflow slice idle past the inactivity threshold, confirm it gets removed on the next sweep
- [x] Confirm active workflows (touched within the threshold) are not pruned
- [x] Verify the service tolerates a single failed sweep without taking the host down (next tick retries)