### PR TITLE
Free shipping above order thresholds (#8)

### DIFF
--- a/src/CompositionGateway/Program.cs
+++ b/src/CompositionGateway/Program.cs
@@ -15,8 +15,27 @@ builder.Services.AddCors(options =>
                        .AllowAnyHeader();
             }));
 builder.Services.AddHttpContextAccessor();
-builder.Services.AddViewModelComposition();
-builder.Services.AddControllers();
+builder.Services.AddViewModelComposition(options =>
+{
+    // Required so composers can call request.SetActionResult(...) to
+    // short-circuit a composed response (e.g. returning 410 Gone when
+    // a cart slice has been reaped). ServiceComposer 5.2 refuses to
+    // honour an action result unless output formatters are wired in.
+    options.ResponseSerialization.UseOutputFormatters = true;
+});
+builder.Services.AddControllers()
+    .AddJsonOptions(json =>
+    {
+        // Output formatters serialize ExpandoObject keys verbatim;
+        // composers assign PascalCase (vm.Products = ...) but the
+        // SvelteKit frontend reads camelCase. Make the formatter
+        // lowercase the first letter so the wire shape stays the
+        // same as ServiceComposer's own writer used to produce.
+        json.JsonSerializerOptions.PropertyNamingPolicy =
+            System.Text.Json.JsonNamingPolicy.CamelCase;
+        json.JsonSerializerOptions.DictionaryKeyPolicy =
+            System.Text.Json.JsonNamingPolicy.CamelCase;
+    });
 builder.Services.AddHealthChecks();
 
 var endpointConfiguration = new EndpointConfiguration("CompositionGateway");

--- a/src/Finance.Data/Domain/ShippingFees.cs
+++ b/src/Finance.Data/Domain/ShippingFees.cs
@@ -1,0 +1,16 @@
+using Finance.Data.Models;
+
+namespace Finance.Data.Domain;
+
+// Single source of truth for what a delivery option actually costs on
+// a given order. Callers compute the items subtotal in whatever way
+// fits their context (live composer slice, persisted Order, etc.) and
+// ask for the effective price; this class never touches the DB or the
+// workflow store.
+public static class ShippingFees
+{
+    public static decimal EffectivePrice(DeliveryOption option, decimal itemsSubtotal)
+        => option.FreeShippingThreshold is { } threshold && itemsSubtotal > threshold
+            ? 0m
+            : option.Price;
+}

--- a/src/Finance.Data/Models/DeliveryOption.cs
+++ b/src/Finance.Data/Models/DeliveryOption.cs
@@ -4,4 +4,7 @@ public class DeliveryOption
 {
     public Guid DeliveryOptionId { get; set; }
     public decimal Price { get; set; }
+
+    // Null means this option is never free, regardless of order size.
+    public decimal? FreeShippingThreshold { get; set; }
 }

--- a/src/Finance.Data/Seed/SeedData.cs
+++ b/src/Finance.Data/Seed/SeedData.cs
@@ -82,9 +82,9 @@ public static class SeedData
     {
         return new List<DeliveryOption>
         {
-            new() { DeliveryOptionId = StandardId, Price = 2 },
-            new() { DeliveryOptionId = ExpeditedId, Price = 6 },
-            new() { DeliveryOptionId = PriorityId, Price = 14 },
+            new() { DeliveryOptionId = StandardId, Price = 2, FreeShippingThreshold = 50m },
+            new() { DeliveryOptionId = ExpeditedId, Price = 6, FreeShippingThreshold = 75m },
+            new() { DeliveryOptionId = PriorityId, Price = 14, FreeShippingThreshold = null },
         };
     }
 

--- a/src/Finance.Endpoint/Handlers/OrderPlacedHandler.cs
+++ b/src/Finance.Endpoint/Handlers/OrderPlacedHandler.cs
@@ -1,5 +1,6 @@
 using Catalog.Endpoint.Messages.Events;
 using Finance.Data;
+using Finance.Data.Domain;
 using Finance.Data.Models;
 using Finance.Endpoint.Messages.Events;
 using Microsoft.EntityFrameworkCore;
@@ -45,15 +46,16 @@ public class OrderPlacedHandler(FinanceDbContext dbContext) : IHandleMessages<Or
 
         // Shipping is only charged when at least one line shipped. A
         // partial order still pays the full delivery fee - we packed
-        // and dispatched a box, just with fewer items in it.
+        // and dispatched a box, just with fewer items in it. The free
+        // shipping threshold is re-evaluated against the fulfilled
+        // subtotal, so a partial that drops the order below the
+        // threshold correctly re-introduces the shipping charge.
         if (itemsTotal == 0 || order.DeliveryOptionId is null)
             return itemsTotal;
 
-        var deliveryPrice = await dbContext.DeliveryOptions
-            .Where(d => d.DeliveryOptionId == order.DeliveryOptionId)
-            .Select(d => d.Price)
-            .SingleAsync(ct);
+        var deliveryOption = await dbContext.DeliveryOptions
+            .SingleAsync(d => d.DeliveryOptionId == order.DeliveryOptionId, ct);
 
-        return itemsTotal + deliveryPrice;
+        return itemsTotal + ShippingFees.EffectivePrice(deliveryOption, itemsTotal);
     }
 }

--- a/src/Finance.ServiceComposition/Checkout/OnDeliveryOptionsLoaded.cs
+++ b/src/Finance.ServiceComposition/Checkout/OnDeliveryOptionsLoaded.cs
@@ -1,4 +1,6 @@
 using Finance.Data;
+using Finance.Data.Domain;
+using Finance.ServiceComposition.Helpers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using ServiceComposer.AspNetCore;
@@ -6,17 +8,21 @@ using Shipping.ServiceComposition.Events;
 
 namespace Finance.ServiceComposition.Checkout;
 
-public class OnDeliveryOptionsLoaded(FinanceDbContext dbContext) : ICompositionEventsHandler<DeliveryOptionsLoaded>
+public class OnDeliveryOptionsLoaded(FinanceDbContext dbContext, OrderSubtotalReader orderReader)
+    : ICompositionEventsHandler<DeliveryOptionsLoaded>
 {
     public async Task Handle(DeliveryOptionsLoaded @event, HttpRequest request)
     {
-        var results = await dbContext.DeliveryOptions
-            .ToListAsync(request.HttpContext.RequestAborted);
+        var ct = request.HttpContext.RequestAborted;
+        var orderId = Guid.Parse((string)request.RouteValues["orderId"]!);
+
+        var options = await dbContext.DeliveryOptions.ToListAsync(ct);
+        var itemsSubtotal = await orderReader.GetItemsSubtotalAsync(orderId, ct);
 
         foreach (var deliveryOption in @event.DeliveryOptions)
         {
-            var matchingOption = results.Single(s => s.DeliveryOptionId == deliveryOption.Key);
-            deliveryOption.Value.Price = matchingOption.Price;
+            var match = options.Single(s => s.DeliveryOptionId == deliveryOption.Key);
+            deliveryOption.Value.Price = ShippingFees.EffectivePrice(match, itemsSubtotal);
         }
     }
 }

--- a/src/Finance.ServiceComposition/Checkout/OnDeliverySummaryLoaded.cs
+++ b/src/Finance.ServiceComposition/Checkout/OnDeliverySummaryLoaded.cs
@@ -1,4 +1,5 @@
 using Finance.Data;
+using Finance.Data.Domain;
 using Finance.ServiceComposition.Helpers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
@@ -7,16 +8,23 @@ using Shipping.ServiceComposition.Events;
 
 namespace Finance.ServiceComposition.Checkout;
 
-public class OnDeliverySummaryLoaded(FinanceDbContext dbContext) : ICompositionEventsHandler<DeliverySummaryLoaded>
+public class OnDeliverySummaryLoaded(FinanceDbContext dbContext, OrderSubtotalReader orderReader)
+    : ICompositionEventsHandler<DeliverySummaryLoaded>
 {
     public async Task Handle(DeliverySummaryLoaded @event, HttpRequest request)
     {
-        var deliveryOption = await dbContext.DeliveryOptions
-            .SingleAsync(s => s.DeliveryOptionId == @event.DeliveryOptionId, request.HttpContext.RequestAborted);
+        var ct = request.HttpContext.RequestAborted;
+        var orderId = Guid.Parse((string)request.RouteValues["orderId"]!);
 
-        @event.DeliveryOption.Price = deliveryOption.Price;
+        var deliveryOption = await dbContext.DeliveryOptions
+            .SingleAsync(s => s.DeliveryOptionId == @event.DeliveryOptionId, ct);
+
+        var itemsSubtotal = await orderReader.GetItemsSubtotalAsync(orderId, ct);
+        var effectivePrice = ShippingFees.EffectivePrice(deliveryOption, itemsSubtotal);
+
+        @event.DeliveryOption.Price = effectivePrice;
 
         var vm = request.GetComposedResponseModel();
-        DynamicHelper.TrySetTotalPrice(vm, deliveryOption.Price);
+        DynamicHelper.TrySetTotalPrice(vm, effectivePrice);
     }
 }

--- a/src/Finance.ServiceComposition/Checkout/OnSummaryLoaded.cs
+++ b/src/Finance.ServiceComposition/Checkout/OnSummaryLoaded.cs
@@ -1,63 +1,17 @@
 using Catalog.ServiceComposition.Events;
-using Finance.Data;
 using Finance.Data.Models;
 using Finance.ServiceComposition.Helpers;
-using Finance.ServiceComposition.Workflow;
 using Microsoft.AspNetCore.Http;
-using Microsoft.EntityFrameworkCore;
 using ServiceComposer.AspNetCore;
-using WorkflowComposer;
 
 namespace Finance.ServiceComposition.Checkout;
 
-public class OnSummaryLoaded(FinanceDbContext dbContext, IWorkflowStore workflow) : ICompositionEventsHandler<SummaryLoaded>
+public class OnSummaryLoaded(OrderSubtotalReader orderReader) : ICompositionEventsHandler<SummaryLoaded>
 {
     public async Task Handle(SummaryLoaded @event, HttpRequest request)
     {
-        var orderId = @event.OrderId;
         var ct = request.HttpContext.RequestAborted;
-
-        var order = await dbContext.Orders
-            .Include(o => o.Items)
-            .FirstOrDefaultAsync(s => s.OrderId == orderId, ct);
-
-        if (order == null)
-        {
-            // Finance hasn't processed SubmitOrderItems yet - on this
-            // branch that's the normal pre-submit state, since
-            // SubmitOrderItems is now dispatched together with
-            // CompleteOrder when the customer clicks "Place order".
-            // Fall back to the in-flight slice and stitch in the
-            // current per-product Price/Discount from Finance.Products
-            // so the summary shows real per-line and grand totals
-            // instead of zeros. The eventually-persisted OrderItem will
-            // be the snapshot at submit time; this is the preview.
-            var slice = await workflow.Read<OrderItemsSlice>(orderId, OrderItemsWorkflowSlice.Key, ct);
-            order = new Order { OrderId = orderId };
-            if (slice is not null && slice.Items.Count > 0)
-            {
-                var productIds = slice.Items.Select(i => i.ProductId).ToList();
-                var prices = await dbContext.Products
-                    .Where(p => productIds.Contains(p.ProductId))
-                    .ToDictionaryAsync(p => p.ProductId, ct);
-
-                foreach (var line in slice.Items)
-                {
-                    var item = new OrderItem
-                    {
-                        OrderId = orderId,
-                        ProductId = line.ProductId,
-                        Quantity = line.Quantity
-                    };
-                    if (prices.TryGetValue(line.ProductId, out var product))
-                    {
-                        item.Price = product.Price;
-                        item.Discount = product.Discount;
-                    }
-                    order.Items.Add(item);
-                }
-            }
-        }
+        var order = await orderReader.GetOrderWithItemsAsync(@event.OrderId, ct);
 
         var totalPrice = 0m;
 

--- a/src/Finance.ServiceComposition/Email/OrderSummaryComposer.cs
+++ b/src/Finance.ServiceComposition/Email/OrderSummaryComposer.cs
@@ -1,5 +1,6 @@
 using System.Dynamic;
 using Finance.Data;
+using Finance.Data.Domain;
 using Finance.Data.Models;
 using Finance.ServiceComposition.Events;
 using Finance.ServiceComposition.Workflow;
@@ -33,8 +34,13 @@ public class OrderSummaryComposer(FinanceDbContext dbContext, IHttpContextAccess
         var deliveryOption = row.DeliveryOption;
         var billingAddress = order.BillingAddress!;
 
+        // Match the OrderPlacedHandler view: fulfilled items only.
+        var itemsSubtotal = order.Items
+            .Where(i => i.Fulfilled)
+            .Sum(i => i.EffectivePrice() * i.Quantity);
+
         dynamic deliveryOptionModel = new ExpandoObject();
-        deliveryOptionModel.Price = deliveryOption.Price;
+        deliveryOptionModel.Price = ShippingFees.EffectivePrice(deliveryOption, itemsSubtotal);
 
         var context = request.GetCompositionContext();
         await context.RaiseEvent(new DeliveryOptionLoaded()

--- a/src/Finance.ServiceComposition/Helpers/OrderSubtotalReader.cs
+++ b/src/Finance.ServiceComposition/Helpers/OrderSubtotalReader.cs
@@ -1,0 +1,65 @@
+using Finance.Data;
+using Finance.Data.Models;
+using Finance.ServiceComposition.Workflow;
+using Microsoft.EntityFrameworkCore;
+using WorkflowComposer;
+
+namespace Finance.ServiceComposition.Helpers;
+
+// Materializes the line items for an order as Finance currently sees
+// them, regardless of whether the order has been submitted yet.
+//
+// Composers run in two phases of the checkout. Pre-submit there is no
+// persisted Order yet (SubmitOrderItems is dispatched together with
+// CompleteOrder), so items live in the workflow slice and are priced
+// against the current Finance.Products row. Post-submit the persisted
+// Order.Items is the snapshot at submit time. Both paths return
+// OrderItems whose Price/Discount/Quantity feed the same downstream
+// subtotal math.
+public class OrderSubtotalReader(FinanceDbContext dbContext, IWorkflowStore workflow)
+{
+    public async Task<Order> GetOrderWithItemsAsync(Guid orderId, CancellationToken ct)
+    {
+        var order = await dbContext.Orders
+            .Include(o => o.Items)
+            .FirstOrDefaultAsync(o => o.OrderId == orderId, ct);
+
+        if (order is not null)
+            return order;
+
+        order = new Order { OrderId = orderId };
+
+        var slice = await workflow.Read<OrderItemsSlice>(orderId, OrderItemsWorkflowSlice.Key, ct);
+        if (slice is null || slice.Items.Count == 0)
+            return order;
+
+        var productIds = slice.Items.Select(i => i.ProductId).ToList();
+        var prices = await dbContext.Products
+            .Where(p => productIds.Contains(p.ProductId))
+            .ToDictionaryAsync(p => p.ProductId, ct);
+
+        foreach (var line in slice.Items)
+        {
+            var item = new OrderItem
+            {
+                OrderId = orderId,
+                ProductId = line.ProductId,
+                Quantity = line.Quantity
+            };
+            if (prices.TryGetValue(line.ProductId, out var product))
+            {
+                item.Price = product.Price;
+                item.Discount = product.Discount;
+            }
+            order.Items.Add(item);
+        }
+
+        return order;
+    }
+
+    public async Task<decimal> GetItemsSubtotalAsync(Guid orderId, CancellationToken ct)
+    {
+        var order = await GetOrderWithItemsAsync(orderId, ct);
+        return order.Items.Sum(i => i.EffectivePrice() * i.Quantity);
+    }
+}

--- a/src/Finance.ServiceComposition/Startup.cs
+++ b/src/Finance.ServiceComposition/Startup.cs
@@ -1,5 +1,6 @@
 using Finance.Data;
 using Finance.Endpoint.Messages.Commands;
+using Finance.ServiceComposition.Helpers;
 using ITOps.Shared.EndpointConfiguration;
 using ITOps.Shared.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -15,6 +16,7 @@ public class Startup : IViewModelCompositionOptionsCustomization, IConfigureEndp
     {
         options.Services.AddDbContext<FinanceDbContext>(opts =>
             opts.UseSqlite(SqliteStorage.GetConnectionString("finance")));
+        options.Services.AddScoped<OrderSubtotalReader>();
     }
 
     public void ConfigureRouting(RoutingSettings<LearningTransport> routing)

--- a/src/OmNomNom.BackOffice/Views/Emails/EmailContent.cshtml
+++ b/src/OmNomNom.BackOffice/Views/Emails/EmailContent.cshtml
@@ -9,6 +9,8 @@
         "$" + v.ToString("0.00", CultureInfo.InvariantCulture);
     Func<decimal, string> formatSigned = v =>
         (v < 0 ? "-$" : "$") + Math.Abs(v).ToString("0.00", CultureInfo.InvariantCulture);
+    Func<decimal, string> formatShipping = v =>
+        v <= 0m ? "FREE" : formatMoney(v);
 
     // Walk the products once to (a) build per-row presentation data and
     // (b) accumulate the totals breakdown. Trusting Model.totalPrice as
@@ -173,7 +175,7 @@
                                         <div style="font-family: 'Outfit', sans-serif; font-size: 13px; color: #7a6f62; margin: 0;">@deliveryDescription</div>
                                     </td>
                                     <td valign="middle" align="right" style="padding: 16px 0; white-space: nowrap;">
-                                        <div style="font-family: 'Outfit', sans-serif; font-weight: 700; font-size: 18px; color: #f0e6d8; line-height: 1;">@formatMoney(shippingPrice)</div>
+                                        <div style="font-family: 'Outfit', sans-serif; font-weight: 700; font-size: 18px; color: #f0e6d8; line-height: 1;">@formatShipping(shippingPrice)</div>
                                     </td>
                                 </tr>
                             </table>
@@ -201,7 +203,7 @@
                                 }
                                 <tr>
                                     <td style="padding: 8px 0; font-family: 'Outfit', sans-serif; font-size: 14px; color: #a89b8a;">Shipping</td>
-                                    <td align="right" style="padding: 8px 0; font-family: 'Outfit', sans-serif; font-size: 14px; color: #f0e6d8; font-weight: 500;">@formatMoney(shippingPrice)</td>
+                                    <td align="right" style="padding: 8px 0; font-family: 'Outfit', sans-serif; font-size: 14px; color: #f0e6d8; font-weight: 500;">@formatShipping(shippingPrice)</td>
                                 </tr>
                                 <tr>
                                     <td colspan="2" style="border-top: 1px solid #3a3530; padding: 0; line-height: 0; font-size: 0;">&nbsp;</td>

--- a/src/OmNomNom.BackOffice/Views/Emails/PartiallyFulfilledEmailContent.cshtml
+++ b/src/OmNomNom.BackOffice/Views/Emails/PartiallyFulfilledEmailContent.cshtml
@@ -7,6 +7,8 @@
         "$" + v.ToString("0.00", CultureInfo.InvariantCulture);
     Func<decimal, string> formatSigned = v =>
         (v < 0 ? "-$" : "$") + Math.Abs(v).ToString("0.00", CultureInfo.InvariantCulture);
+    Func<decimal, string> formatShipping = v =>
+        v <= 0m ? "FREE" : formatMoney(v);
 
     // Two passes over the products: fulfilled lines drive the
     // shipped-items list and the totals breakdown; unfulfilled lines
@@ -180,7 +182,7 @@
                                         <div style="font-family: 'Outfit', sans-serif; font-size: 13px; color: #7a6f62; margin: 0;">@deliveryDescription</div>
                                     </td>
                                     <td valign="middle" align="right" style="padding: 16px 0; white-space: nowrap;">
-                                        <div style="font-family: 'Outfit', sans-serif; font-weight: 700; font-size: 18px; color: #f0e6d8; line-height: 1;">@formatMoney(shippingPrice)</div>
+                                        <div style="font-family: 'Outfit', sans-serif; font-weight: 700; font-size: 18px; color: #f0e6d8; line-height: 1;">@formatShipping(shippingPrice)</div>
                                     </td>
                                 </tr>
                             </table>
@@ -254,7 +256,7 @@
                                 }
                                 <tr>
                                     <td style="padding: 8px 0; font-family: 'Outfit', sans-serif; font-size: 14px; color: #a89b8a;">Shipping</td>
-                                    <td align="right" style="padding: 8px 0; font-family: 'Outfit', sans-serif; font-size: 14px; color: #f0e6d8; font-weight: 500;">@formatMoney(shippingPrice)</td>
+                                    <td align="right" style="padding: 8px 0; font-family: 'Outfit', sans-serif; font-size: 14px; color: #f0e6d8; font-weight: 500;">@formatShipping(shippingPrice)</td>
                                 </tr>
                                 <tr>
                                     <td colspan="2" style="border-top: 1px solid #3a3530; padding: 0; line-height: 0; font-size: 0;">&nbsp;</td>

--- a/src/website/src/Finance/OrderSummaryCard.svelte
+++ b/src/website/src/Finance/OrderSummaryCard.svelte
@@ -46,7 +46,7 @@
       <OrderTotal label="Discount" amount={-discountTotal} discount />
     {/if}
     {#if shippingPrice !== null}
-      <OrderTotal label="Shipping" amount={shippingPrice} />
+      <OrderTotal label="Shipping" amount={shippingPrice} freeWhenZero />
     {/if}
     <OrderTotal label="Order Total" amount={total} emphasized />
     {#if children}

--- a/src/website/src/Finance/OrderTotal.svelte
+++ b/src/website/src/Finance/OrderTotal.svelte
@@ -3,10 +3,12 @@
     label = 'Order Total',
     amount = 0,
     emphasized = false,
-    discount = false
+    discount = false,
+    freeWhenZero = false
   } = $props();
   let format = (value) => {
     const n = Number(value ?? 0);
+    if (freeWhenZero && n <= 0) return 'FREE';
     return (n < 0 ? '-$' : '$') + Math.abs(n).toFixed(2);
   };
 </script>

--- a/src/website/src/Shipping/DeliveryOptions.svelte
+++ b/src/website/src/Shipping/DeliveryOptions.svelte
@@ -1,6 +1,9 @@
 <script>
   let { options = [], selectedId = $bindable(null), onSelect = () => {} } = $props();
-  let format = (value) => '$' + Number(value ?? 0).toFixed(2);
+  let format = (value) => {
+    const n = Number(value ?? 0);
+    return n <= 0 ? 'FREE' : '$' + n.toFixed(2);
+  };
 
   function pick(id) {
     selectedId = id;

--- a/src/website/src/routes/buy/summary/[orderId]/+page.svelte
+++ b/src/website/src/routes/buy/summary/[orderId]/+page.svelte
@@ -119,7 +119,7 @@
               {#if summary.deliveryOption.deliveryOptionDescription}
                 <div>{summary.deliveryOption.deliveryOptionDescription}</div>
               {/if}
-              <div>${Number(summary.deliveryOption.price ?? 0).toFixed(2)}</div>
+              <div>{Number(summary.deliveryOption.price ?? 0) <= 0 ? 'FREE' : '$' + Number(summary.deliveryOption.price).toFixed(2)}</div>
             </div>
           </div>
         {/if}


### PR DESCRIPTION
Closes #8.

## Summary
- Finance owns a single decision: `ShippingFees.EffectivePrice(option, subtotal)` returns 0 when the order subtotal clears the option's `FreeShippingThreshold`, otherwise the list price. Seed: Standard free above \$50, Expedited free above \$75, Priority never free.
- Composers (`OnDeliveryOptionsLoaded`, `OnDeliverySummaryLoaded`), the `OrderPlacedHandler`, and the email composer all converge on the same function, so the delivery picker, running summary, charged amount, and shipping email stay consistent — including partial fulfillments that drop the order back under a threshold.
- Shipping boundary, composition contracts, and message contracts unchanged. UI/email render `price <= 0` as `FREE` (presentation only).

A second commit fixes a pre-existing issue independent of #8: the gateway never enabled `UseOutputFormatters`, so the 410-on-reaped-cart composers' `SetActionResult` calls were silently broken. Enabled it and forced camelCase on the JSON output formatter so the wire shape stays the same for the SvelteKit frontend.

## Test plan
Delete the existing Finance SQLite file first so the seed reapplies with the new `FreeShippingThreshold` column.

- [ ] **Subtotal \$30** — `/buy/shipping/{orderId}` shows Standard \$2, Expedited \$6, Priority \$14; full shipping charged; email shows the dollar amount.
- [ ] **Subtotal \$70** — Standard reads `FREE`, Expedited still \$6, Priority \$14. Pick Standard, place order: `ChargedAmount` = \$70 and email shipping row reads `FREE`. Second order at same subtotal picking Expedited still charges \$6.
- [ ] **Subtotal \$90** — both Standard and Expedited read `FREE`, Priority \$14.
- [ ] **Partial fulfillment** — force a stockout so the fulfilled subtotal drops under the threshold; confirm shipping is charged again and the `PartiallyFulfilledEmailContent` email renders accordingly.
- [ ] **Pre-existing 410 path** — let a cart slice expire and hit any cart-dependent page; should now correctly return 410 Gone instead of throwing the `UseOutputFormatters` exception.