### PR TITLE
Stop Catalog and Shipping microviews from formatting money

### DIFF
--- a/src/website/src/Catalog/CartItemRow.svelte
+++ b/src/website/src/Catalog/CartItemRow.svelte
@@ -1,9 +1,8 @@
 <script>
   import Price from '../Finance/Price.svelte';
-  import { effectivePrice } from '../Finance/effectivePrice.js';
+  import LineSubtotal from '../Finance/LineSubtotal.svelte';
 
   let { item, editable = true, onQuantityChange = () => {}, onRemove = () => {} } = $props();
-  let format = (value) => '$' + Number(value ?? 0).toFixed(2);
 </script>
 
 <div class="cart-item" data-product-id={item.productId}>
@@ -47,6 +46,6 @@
     {/if}
   </div>
   <div class="cart-item-subtotal">
-    {format(effectivePrice(item) * item.quantity)}
+    <LineSubtotal {item} />
   </div>
 </div>

--- a/src/website/src/Finance/LineSubtotal.svelte
+++ b/src/website/src/Finance/LineSubtotal.svelte
@@ -1,0 +1,6 @@
+<script>
+  import { effectivePrice } from './effectivePrice.js';
+
+  let { item } = $props();
+  let format = (value) => '$' + Number(value ?? 0).toFixed(2);
+</script>{format(effectivePrice(item) * Number(item?.quantity ?? 0))}

--- a/src/website/src/Finance/ShippingPrice.svelte
+++ b/src/website/src/Finance/ShippingPrice.svelte
@@ -1,0 +1,7 @@
+<script>
+  let { amount = 0 } = $props();
+  let format = (value) => {
+    const n = Number(value ?? 0);
+    return n <= 0 ? 'FREE' : '$' + n.toFixed(2);
+  };
+</script>{format(amount)}

--- a/src/website/src/Shipping/DeliveryOptions.svelte
+++ b/src/website/src/Shipping/DeliveryOptions.svelte
@@ -1,9 +1,7 @@
 <script>
+  import ShippingPrice from '../Finance/ShippingPrice.svelte';
+
   let { options = [], selectedId = $bindable(null), onSelect = () => {} } = $props();
-  let format = (value) => {
-    const n = Number(value ?? 0);
-    return n <= 0 ? 'FREE' : '$' + n.toFixed(2);
-  };
 
   function pick(id) {
     selectedId = id;
@@ -26,7 +24,7 @@
         <div class="shipping-option-name">{option.name}</div>
         <div class="shipping-option-delivery">{option.description}</div>
       </div>
-      <div class="shipping-option-price">{format(option.price)}</div>
+      <div class="shipping-option-price"><ShippingPrice amount={option.price} /></div>
     </label>
   {/each}
 </div>


### PR DESCRIPTION
## Summary
- Audit of frontend microviews surfaced two cases where consumer service folders were rendering monetary values themselves: `Catalog/CartItemRow.svelte` computed and formatted the line subtotal, and `Shipping/DeliveryOptions.svelte` formatted the delivery option price (including the "FREE vs $X.XX" rule).
- Introduces two small Finance microviews (`Finance/LineSubtotal.svelte`, `Finance/ShippingPrice.svelte`) that own the formatting; Catalog and Shipping now pass their data through and keep only their own structural markup/CSS.
- Pure refactor: same rendered output, no contract or backend changes.

## Test plan
- [x] `cd src/website && npm install && npm run dev`
- [x] Cart page: each row still shows the correct subtotal (`unit price × quantity`, with discount applied)
- [x] Buy/shipping page: delivery options still render either "FREE" or `$X.XX` depending on the price contributed by Finance
- [x] Confirm no visual regression on the order summary sidebar