### PR TITLE
Make OmNomNom usable on mobile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,8 @@ npm run dev   # Vite dev server on port 5173 (SvelteKit)
 npm run build
 ```
 
+The dev server binds to `0.0.0.0`, so other devices on the LAN (e.g. a phone for mobile testing) can reach it at `https://<dev-machine-ip>:5173`. The frontend calls the gateway through Vite's proxy at `/api/*`, so the gateway itself stays bound to `localhost` and no CORS configuration is needed. Trust the dev cert once per device (click-through is fine).
+
 ## Architecture
 
 ### Service Decomposition

--- a/src/Catalog.ServiceComposition/Cart/Mapper.cs
+++ b/src/Catalog.ServiceComposition/Cart/Mapper.cs
@@ -6,26 +6,36 @@ namespace Catalog.ServiceComposition.Cart;
 
 public static class Mapper
 {
-    public static IDictionary<Guid, dynamic> MapToDictionary(CartSlice cart, List<Product> products)
+    public static IDictionary<Guid, dynamic> MapToDictionary(
+        CartSlice cart,
+        IReadOnlyDictionary<Guid, (Product Product, int InStock)> productLookup)
     {
         var productsViewModel = new Dictionary<Guid, dynamic>();
 
         foreach (var line in cart.Items)
         {
-            var matchingProduct = products.Single(p => p.ProductId == line.ProductId);
-            productsViewModel[line.ProductId] = MapToViewModel(line, matchingProduct);
+            if (!productLookup.TryGetValue(line.ProductId, out var row))
+            {
+                continue;
+            }
+            productsViewModel[line.ProductId] = MapToViewModel(line, row.Product, row.InStock);
         }
 
         return productsViewModel;
     }
 
-    public static dynamic MapToViewModel(CartLine line, Product product)
+    public static dynamic MapToViewModel(CartLine line, Product product, int inStock)
     {
         dynamic vm = new ExpandoObject();
         vm.ProductId = line.ProductId;
         vm.Quantity = line.Quantity;
         vm.Name = product.Name;
         vm.ImageUrl = product.ImageUrl;
+        // Live ledger count so the cart UI can cap its + button. Cart
+        // composition can race with stock changes from other customers
+        // checking out; the OrderPlacedHandler is still the authority
+        // when an order is finalized.
+        vm.InStock = inStock;
         return vm;
     }
 }

--- a/src/Catalog.ServiceComposition/Cart/ShoppingCartComposer.cs
+++ b/src/Catalog.ServiceComposition/Cart/ShoppingCartComposer.cs
@@ -32,10 +32,24 @@ public class ShoppingCartComposer(IWorkflowStore workflow, CatalogDbContext dbCo
         }
 
         var productIds = cart.Items.Select(s => s.ProductId).ToList();
-        var products = await dbContext.Products
+        // Pull each cart-line product together with its live in-stock
+        // count (sum of the InventoryDelta ledger, same calculation
+        // ProductsComposer uses). The frontend caps its + button on
+        // this so the customer can't queue more units than exist.
+        var productRows = await dbContext.Products
             .Where(s => productIds.Contains(s.ProductId))
+            .Select(p => new
+            {
+                Product = p,
+                InStock = dbContext.InventoryDeltas
+                    .Where(d => d.ProductId == p.ProductId)
+                    .Sum(d => (int?)d.Delta) ?? 0
+            })
             .ToListAsync(ct);
-        var orderedProducts = Mapper.MapToDictionary(cart, products);
+        var productLookup = productRows.ToDictionary(
+            x => x.Product.ProductId,
+            x => (x.Product, x.InStock));
+        var orderedProducts = Mapper.MapToDictionary(cart, productLookup);
 
         var context = request.GetCompositionContext();
         await context.RaiseEvent(new CartLoaded

--- a/src/Catalog.ServiceComposition/Checkout/ShippingScreenCartComposer.cs
+++ b/src/Catalog.ServiceComposition/Checkout/ShippingScreenCartComposer.cs
@@ -1,4 +1,5 @@
 using Catalog.Data;
+using Catalog.Data.Models;
 using Catalog.ServiceComposition.Events;
 using Catalog.ServiceComposition.Workflow;
 using Microsoft.AspNetCore.Http;
@@ -35,8 +36,15 @@ public class ShippingScreenCartComposer(IWorkflowStore workflow, CatalogDbContex
             return;
         }
 
-        var products = await dbContext.Products.ToListAsync(ct);
-        var orderedProducts = Cart.Mapper.MapToDictionary(cart, products);
+        // Items here aren't editable (the shipping page renders them as
+        // a static list), but the Cart mapper now requires an InStock
+        // figure per line — pass 0 since this surface doesn't need it.
+        var productIds = cart.Items.Select(i => i.ProductId).ToList();
+        var productLookup = (await dbContext.Products
+                .Where(p => productIds.Contains(p.ProductId))
+                .ToListAsync(ct))
+            .ToDictionary(p => p.ProductId, p => (Product: p, InStock: 0));
+        var orderedProducts = Cart.Mapper.MapToDictionary(cart, productLookup);
 
         var context = request.GetCompositionContext();
         await context.RaiseEvent(new CartLoaded

--- a/src/website/src/Branding/FilterBar.svelte
+++ b/src/website/src/Branding/FilterBar.svelte
@@ -6,6 +6,12 @@
   //
   // All four controls are optional - pass an empty array (or no
   // sortOptions) to hide a dropdown.
+  //
+  // At mobile widths the three filter dropdowns collapse behind a
+  // single `Filters` button that opens a bottom sheet containing the
+  // same three controls. Sort stays visible in the row. CSS does all
+  // the layout work; this component only owns the open/closed state
+  // and an active-count badge.
 
   import MultiSelect from './MultiSelect.svelte';
 
@@ -26,14 +32,69 @@
   );
   let hasSortDropdown = $derived(sortOptions.length > 0);
 
+  let isSheetOpen = $state(false);
+
+  // One badge across all three dropdowns; "All" is the unselected
+  // sentinel for the single-selects.
+  let activeFilterCount = $derived(
+    selectedCategories.length +
+      (selectedBrewery !== 'All' ? 1 : 0) +
+      (selectedCountry !== 'All' ? 1 : 0)
+  );
+
   function emit() {
     onChange();
   }
+
+  function openSheet() {
+    isSheetOpen = true;
+  }
+
+  function closeSheet() {
+    isSheetOpen = false;
+  }
+
+  function onKeyDown(event) {
+    if (event.key === 'Escape' && isSheetOpen) {
+      closeSheet();
+    }
+  }
 </script>
 
+<svelte:window onkeydown={onKeyDown} />
+
 <div class="filters-row">
-  {#if hasFilterDropdowns || hasSortDropdown}
-    <div class="filter-dropdowns">
+  {#if hasFilterDropdowns}
+    <!-- Mobile-only trigger; hidden on desktop via CSS. -->
+    <button
+      type="button"
+      class="filter-toggle"
+      onclick={openSheet}
+      aria-haspopup="dialog"
+      aria-expanded={isSheetOpen}
+    >
+      Filters{activeFilterCount > 0 ? ` · ${activeFilterCount}` : ''}
+    </button>
+
+    <!-- Inline on desktop, bottom-sheet on mobile (toggled via .is-open). -->
+    <div
+      class="filter-dropdowns"
+      class:is-open={isSheetOpen}
+      role={isSheetOpen ? 'dialog' : undefined}
+      aria-label={isSheetOpen ? 'Filters' : undefined}
+    >
+      <!-- Sheet header is rendered into the DOM unconditionally but
+           only displayed at mobile widths via CSS. -->
+      <div class="filter-sheet-head">
+        <span class="filter-sheet-title">Filters</span>
+        <button
+          type="button"
+          class="filter-sheet-close"
+          onclick={closeSheet}
+          aria-label="Close filters"
+        >×</button>
+      </div>
+
       {#if categories.length > 0}
         <MultiSelect
           label="Type"
@@ -66,20 +127,36 @@
           {/each}
         </select>
       {/if}
-      {#if hasSortDropdown}
-        <div class="sort-group" class:has-filters={hasFilterDropdowns}>
-          <span class="sort-label">Sort by</span>
-          <select
-            class="sort-select"
-            bind:value={selectedSort}
-            onchange={emit}
-          >
-            {#each sortOptions as option}
-              <option value={option.value}>{option.label}</option>
-            {/each}
-          </select>
-        </div>
-      {/if}
+    </div>
+
+    <!-- Backdrop closes the sheet on tap. Only rendered when open so
+         it doesn't intercept clicks elsewhere. -->
+    {#if isSheetOpen}
+      <button
+        type="button"
+        class="filter-sheet-backdrop"
+        onclick={closeSheet}
+        aria-label="Close filters"
+      ></button>
+    {/if}
+  {/if}
+
+  {#if hasSortDropdown}
+    <!-- Sibling of .filter-dropdowns (not nested) so .filters-row's
+         `justify-content: space-between` + `flex-wrap: wrap` can keep
+         Sort pinned to the right and let it wrap onto its own row
+         independently of how wide the filter chips become. -->
+    <div class="sort-group" class:has-filters={hasFilterDropdowns}>
+      <span class="sort-label">Sort by</span>
+      <select
+        class="sort-select"
+        bind:value={selectedSort}
+        onchange={emit}
+      >
+        {#each sortOptions as option}
+          <option value={option.value}>{option.label}</option>
+        {/each}
+      </select>
     </div>
   {/if}
 </div>

--- a/src/website/src/Branding/styles/global.css
+++ b/src/website/src/Branding/styles/global.css
@@ -672,6 +672,33 @@ img {
     cursor: pointer;
     padding: 0;
   }
+
+  /* OrderSummaryCard is a duplicate running total on cart / address /
+     shipping / payment at phone widths. Hide it once we're in the
+     mobile UI mode (same breakpoint as the filter sheet so the page
+     feels consistent — without this the summary still showed in the
+     601-699px band where everything else had gone mobile). The summary
+     page opts out by passing children (the Place Order button) — see
+     OrderSummaryCard.svelte. */
+  .order-summary-mobile-hidden {
+    display: none;
+  }
+
+  /* The cart page renders OrderTotalLine as a mobile-only substitute
+     for the hidden sidebar so the customer still sees the running
+     total before tapping Proceed. Hidden by default outside this
+     media query. */
+  .order-total-line {
+    display: flex;
+  }
+
+  /* Generic escape hatch for blocks that callers want gone at phone
+     widths. Currently used by the shipping page's "Shipping from
+     OmNomNom" items review, which duplicates the cart contents and
+     adds scrolling between Delivery Speed and Continue. */
+  .mobile-hidden {
+    display: none;
+  }
 }
 
 /* Multi-select trigger reuses .filter-select; the wrapper just owns
@@ -1564,11 +1591,21 @@ img {
   color: var(--color-danger);
   font-weight: 500;
   transition: opacity 0.2s;
+  display: inline-flex;
+  align-items: center;
 }
 
 .cart-remove-btn:hover {
   opacity: 0.8;
+}
+.cart-remove-btn:hover .cart-remove-text {
   text-decoration: underline;
+}
+
+/* Icon is hidden on desktop (the text label takes over); the mobile
+   media query flips this so the trash glyph replaces the label. */
+.cart-remove-icon {
+  display: none;
 }
 
 .cart-item-subtotal {
@@ -2192,6 +2229,33 @@ img {
   }
 }
 
+/* Mobile-only Order Total pill that sits below the cart items when the
+   OrderSummary sidebar is hidden. Hidden by default; the mobile media
+   query flips display to flex. Styling lives here so the appearance is
+   shared with anywhere else we ever surface OrderTotalLine. */
+.order-total-line {
+  display: none;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 16px 18px;
+  margin-top: 16px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-md);
+}
+.order-total-line-label {
+  font-family: var(--font-display);
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+.order-total-line-amount {
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--color-cream);
+}
+
 @media (max-width: 600px) {
   .beer-grid {
     grid-template-columns: 1fr;
@@ -2201,12 +2265,91 @@ img {
     grid-template-columns: 1fr;
   }
 
+  /* Mobile cart item: flatten the .cart-item-details and
+     .cart-item-controls wrappers with display: contents so the inner
+     name / price / qty / Remove can be placed directly via grid-area
+     on .cart-item. The bottom row holds qty-stepper, the trash button
+     (right next to +), and the subtotal pushed to the right edge.
+     Sizing qty and remove as auto columns prevents the stepper from
+     stretching past the + button. */
   .cart-item {
-    grid-template-columns: 80px 1fr;
+    grid-template-columns: 80px auto auto 1fr;
+    grid-template-areas:
+      "image name     name      name"
+      "image price    price     price"
+      "image qty      remove    subtotal";
+    column-gap: 12px;
+    row-gap: 4px;
+    padding: 16px;
+  }
+
+  .cart-item-image {
+    /* The image element was 100px and overflowed the now-80px column,
+       eating the column gap so the title sat flush against the image. */
+    width: 80px;
+    height: 80px;
+    grid-area: image;
+  }
+
+  .cart-item-details,
+  .cart-item-controls {
+    display: contents;
+  }
+
+  .cart-item-name {
+    grid-area: name;
+  }
+
+  .cart-item-price {
+    grid-area: price;
+  }
+
+  .qty-control,
+  .cart-item-qty {
+    grid-area: qty;
+    justify-self: start;
   }
 
   .cart-item-subtotal {
-    grid-column: 2;
+    grid-area: subtotal;
+    justify-self: end;
+    align-self: center;
+  }
+
+  /* The text label loses to the trash glyph at mobile widths so the
+     control fits next to the + button. */
+  .cart-remove-btn {
+    grid-area: remove;
+    justify-self: start;
+    align-self: center;
+    padding: 6px;
+    line-height: 0;
+  }
+  .cart-remove-text {
+    display: none;
+  }
+  .cart-remove-icon {
+    display: block;
+  }
+
+  /* Mobile progress bar: 5 labelled steps overflowed the viewport at
+     phone widths. Hide labels (each circle is still numbered), shrink
+     the circle, and drop the label-compensating margin on connectors. */
+  .progress-bar-container {
+    padding: 14px 12px;
+  }
+  .step-circle {
+    width: 28px;
+    height: 28px;
+    font-size: 12px;
+  }
+  .step-label {
+    display: none;
+  }
+  .step-connector {
+    min-width: 0;
+    margin: 0 6px;
+    margin-bottom: 0;
   }
 
   .page-title {

--- a/src/website/src/Branding/styles/global.css
+++ b/src/website/src/Branding/styles/global.css
@@ -1573,9 +1573,17 @@ img {
   transition: all 0.2s;
 }
 
-.qty-btn:hover {
+.qty-btn:hover:not(:disabled) {
   background: var(--color-surface-hover);
   color: var(--color-primary);
+}
+
+.qty-btn:disabled {
+  /* + button is capped at the live in-stock figure. Muted styling
+     plus the not-allowed cursor signals why the customer can't keep
+     pressing it. */
+  opacity: 0.35;
+  cursor: not-allowed;
 }
 
 .qty-value {

--- a/src/website/src/Branding/styles/global.css
+++ b/src/website/src/Branding/styles/global.css
@@ -153,6 +153,12 @@ img {
   font-size: 38px;
   filter: drop-shadow(0 2px 4px rgba(0,0,0,0.3));
   grid-row: 1 / 3;
+  /* The grid container is `align-items: end` so the wordmark sits flush
+     with the tagline below it. Override here so the mug glyph centers
+     against the full text block (wordmark + tagline) instead of dropping
+     to the bottom of its row span, which made the wordmark look like it
+     was floating high in the header. */
+  align-self: center;
 }
 
 .logo-text {
@@ -178,6 +184,17 @@ img {
 }
 
 @media (max-width: 699px) {
+  /* Tagline is hidden on mobile, so the grid collapses to one visible
+     row. The icon's emoji glyph has a tall descender area which pushed
+     it visually below the wordmark even with align-self: center. Switch
+     to a plain flex row at mobile: icon and wordmark land on the same
+     baseline with no row-span math. */
+  .logo {
+    display: flex;
+    align-items: center;
+    column-gap: 10px;
+  }
+
   .logo-tagline {
     display: none;
   }
@@ -478,6 +495,13 @@ img {
   display: flex;
   align-items: center;
   gap: 8px;
+  /* Sort sits as a direct sibling of `.filter-dropdowns` under
+     `.filters-row` (which uses `justify-content: space-between` and
+     `flex-wrap: wrap`). margin-left:auto keeps the group pinned to the
+     right edge whether it shares the row with filters or wraps onto a
+     line of its own — so changing the Type selection no longer shoves
+     the layout around. */
+  margin-left: auto;
 }
 
 .sort-group.has-filters {
@@ -521,12 +545,150 @@ img {
   box-shadow: 0 0 0 3px var(--color-primary-light);
 }
 
+/* Mobile filter sheet: the inline three-dropdown row becomes a single
+   `Filters` button on phones; tapping it slides a bottom sheet up with
+   the same three controls. All styles below are hidden on desktop and
+   only activate under the mobile breakpoint further down. */
+.filter-toggle,
+.filter-sheet-head,
+.filter-sheet-backdrop {
+  display: none;
+}
+
+@media (max-width: 699px) {
+  /* Mobile-only trigger chip. Reuses the .filter-select look but is a
+     plain button so it doesn't carry the native <select> caret glyph. */
+  .filter-toggle {
+    display: inline-flex;
+    align-items: center;
+    padding: 10px 18px;
+    border-radius: 100px;
+    font-size: 14px;
+    font-weight: 500;
+    font-family: var(--font-body);
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    transition: all 0.25s;
+  }
+  .filter-toggle:hover,
+  .filter-toggle:focus-visible {
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+    outline: none;
+  }
+
+  /* The inline dropdowns row collapses by default on mobile, then
+     re-appears as a bottom sheet when .is-open is toggled. */
+  .filter-dropdowns {
+    display: none;
+  }
+  .filter-dropdowns.is-open {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 200;
+    padding: 16px 20px 24px;
+    background: var(--color-surface);
+    border-top-left-radius: 18px;
+    border-top-right-radius: 18px;
+    box-shadow: 0 -12px 32px rgba(0, 0, 0, 0.35);
+    max-height: 80vh;
+    overflow-y: auto;
+  }
+
+  /* Sheet header (title + close). Hidden on desktop above; shown here. */
+  .filter-dropdowns.is-open .filter-sheet-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-bottom: 4px;
+    border-bottom: 1px solid var(--color-border-light);
+  }
+  .filter-sheet-title {
+    font-family: var(--font-display);
+    font-size: 18px;
+    font-weight: 700;
+    color: var(--color-text-primary);
+  }
+  .filter-sheet-close {
+    background: none;
+    border: 0;
+    font-size: 28px;
+    line-height: 1;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    padding: 4px 10px;
+    border-radius: var(--radius-sm);
+  }
+  .filter-sheet-close:hover {
+    color: var(--color-primary);
+  }
+
+  /* Each control sits on its own full-width row inside the sheet. */
+  .filter-dropdowns.is-open .multiselect,
+  .filter-dropdowns.is-open .filter-select,
+  .filter-dropdowns.is-open .multiselect-trigger {
+    width: 100%;
+  }
+
+  /* .multiselect is normally `display: inline-flex` so the absolute
+     popup floats over the page next to the trigger. Inside the sheet
+     we render the popup inline (below the trigger), so the wrapper
+     needs to stack its children vertically. */
+  .filter-dropdowns.is-open .multiselect {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  /* Type's checkbox popup is normally an absolutely-positioned overlay
+     anchored to the trigger. Inside the sheet that would float over the
+     other controls; flow it inline instead so the sheet just grows
+     (scrolls) when Type is open. */
+  .filter-dropdowns.is-open .multiselect-popup {
+    position: relative;
+    top: auto;
+    left: auto;
+    width: 100%;
+    margin-top: 6px;
+    max-height: 240px;
+    box-shadow: none;
+  }
+
+  /* Backdrop sits below the sheet (z-index 199) but above the page. */
+  .filter-sheet-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 199;
+    background: rgba(0, 0, 0, 0.5);
+    border: 0;
+    cursor: pointer;
+    padding: 0;
+  }
+}
+
 /* Multi-select trigger reuses .filter-select; the wrapper just owns
    the popup positioning and a small "× clear" affordance when there
    are selections. */
 .multiselect {
   position: relative;
   display: inline-flex;
+}
+
+/* The trigger is a <button>, so its default text-align is `center`.
+   That looks identical to the native <select> when the chip auto-sizes
+   to its label on desktop, but inside the mobile sheet the chip stretches
+   to full width and the centered label no longer matches the left-aligned
+   <select> options below it. Match the <select> behaviour everywhere. */
+.multiselect-trigger {
+  text-align: left;
 }
 
 .multiselect-trigger.has-selection {

--- a/src/website/src/Catalog/CartItemRow.svelte
+++ b/src/website/src/Catalog/CartItemRow.svelte
@@ -37,8 +37,33 @@
             +
           </button>
         </div>
-        <button type="button" class="cart-remove-btn" onclick={() => onRemove(item.productId)}>
-          Remove
+        <button
+          type="button"
+          class="cart-remove-btn"
+          onclick={() => onRemove(item.productId)}
+          aria-label="Remove {item.name} from cart"
+        >
+          <!-- Text label is hidden on mobile via CSS; the trash glyph
+               takes its place so the action fits next to the qty stepper. -->
+          <span class="cart-remove-text">Remove</span>
+          <svg
+            class="cart-remove-icon"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            width="20"
+            height="20"
+            aria-hidden="true"
+          >
+            <path d="M3 6h18" />
+            <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+            <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+            <path d="M10 11v6" />
+            <path d="M14 11v6" />
+          </svg>
         </button>
       </div>
     {:else}

--- a/src/website/src/Catalog/CartItemRow.svelte
+++ b/src/website/src/Catalog/CartItemRow.svelte
@@ -3,6 +3,13 @@
   import LineSubtotal from '../Finance/LineSubtotal.svelte';
 
   let { item, editable = true, onQuantityChange = () => {}, onRemove = () => {} } = $props();
+
+  // The cart endpoint surfaces the live in-stock count per line. Cap
+  // the + button at that figure so the customer can't queue more units
+  // than exist; if the API ever omits inStock fall back to a generous
+  // ceiling rather than blocking all increments.
+  let stockLimit = $derived(item?.inStock ?? Number.POSITIVE_INFINITY);
+  let canIncrease = $derived(item.quantity < stockLimit);
 </script>
 
 <div class="cart-item" data-product-id={item.productId}>
@@ -33,6 +40,7 @@
             class="qty-btn"
             onclick={() => onQuantityChange(item.productId, item.quantity + 1)}
             aria-label="Increase quantity"
+            disabled={!canIncrease}
           >
             +
           </button>

--- a/src/website/src/Finance/OrderSummaryCard.svelte
+++ b/src/website/src/Finance/OrderSummaryCard.svelte
@@ -38,7 +38,13 @@
   let total = $derived(totalOverride ?? computedTotal);
 </script>
 
-<aside>
+<!-- Hidden on mobile unless the caller passes children. On the summary
+     page the Place-Order button lives inside this card as children, so
+     the card must stay visible. The other checkout pages (cart, address,
+     shipping, payment) include the card purely as a running-total
+     sidebar, which competes for scarce vertical space on a phone — the
+     user will see the final total on the summary step regardless. -->
+<aside class:order-summary-mobile-hidden={!children}>
   <div class="sidebar-card">
     <h3 class="sidebar-title">Order Summary</h3>
     <OrderTotal label="Items" amount={itemsSubtotal} />

--- a/src/website/src/Finance/OrderTotalLine.svelte
+++ b/src/website/src/Finance/OrderTotalLine.svelte
@@ -1,0 +1,28 @@
+<script>
+  // Compact "Order Total: $XX.XX" pill used in places where the full
+  // OrderSummaryCard sidebar isn't shown (mobile cart, today). Reuses
+  // the same pricing math via effectivePrice so the figure can never
+  // drift from what the sidebar shows on desktop.
+
+  import { discountAmount } from './effectivePrice.js';
+
+  let { items = [], shippingPrice = null, totalOverride = null } = $props();
+
+  let total = $derived(
+    totalOverride ??
+      items.reduce(
+        (sum, it) =>
+          sum +
+          (Number(it?.price ?? 0) - discountAmount(it)) *
+            Number(it?.quantity ?? 0),
+        0
+      ) + Number(shippingPrice ?? 0)
+  );
+
+  let format = (value) => '$' + Number(value ?? 0).toFixed(2);
+</script>
+
+<div class="order-total-line">
+  <span class="order-total-line-label">Order Total</span>
+  <span class="order-total-line-amount">{format(total)}</span>
+</div>

--- a/src/website/src/lib/api/gateway.js
+++ b/src/website/src/lib/api/gateway.js
@@ -2,8 +2,13 @@
 // this URL — every per-service composer contributes its slice of each
 // response server-side, and microviews consume slices passed down by the
 // Branding page that owns the route.
+//
+// Calls go same-origin under `/api/...` and are forwarded to the gateway
+// by Vite's dev proxy (see vite.config.js). Same-origin keeps mobile
+// testing simple: the phone only has to trust the Vite cert once and
+// CORS never enters the picture.
 
-const BASE = 'https://localhost:7126';
+const BASE = '/api';
 
 async function getJson(path) {
   const response = await fetch(`${BASE}${path}`);

--- a/src/website/src/routes/buy/shipping/[orderId]/+page.svelte
+++ b/src/website/src/routes/buy/shipping/[orderId]/+page.svelte
@@ -73,7 +73,12 @@
         </div>
 
         {#if cartItems.length > 0}
-          <div class="form-section">
+          <!-- Items review on the shipping page duplicates what the
+               customer already saw in the cart. Helpful as desktop
+               context next to the delivery picker, but on mobile it's
+               just another scroll between Delivery Speed and Continue;
+               hidden under the mobile breakpoint via .mobile-hidden. -->
+          <div class="form-section mobile-hidden">
             <h2>Shipping from OmNomNom</h2>
             <CartItemList items={cartItems} editable={false} />
           </div>

--- a/src/website/src/routes/cart/[orderId]/+page.svelte
+++ b/src/website/src/routes/cart/[orderId]/+page.svelte
@@ -10,6 +10,7 @@
   import CartItemList from '../../../Catalog/CartItemList.svelte';
   import ExpiredCartNotice from '../../../Catalog/ExpiredCartNotice.svelte';
   import OrderSummaryCard from '../../../Finance/OrderSummaryCard.svelte';
+  import OrderTotalLine from '../../../Finance/OrderTotalLine.svelte';
 
   let items = $state([]);
   let loading = $state(true);
@@ -92,6 +93,11 @@
           onRemove={removeItem}
         />
         {#if items.length > 0}
+          <!-- Mobile-only fallback for the (hidden) OrderSummary sidebar
+               so the customer still sees a running total before tapping
+               Proceed. CSS pins this to mobile widths; desktop continues
+               to use the sidebar card. -->
+          <OrderTotalLine {items} />
           <div class="btn-group">
             <button type="button" class="btn-secondary" onclick={discardCart}>
               Discard Cart

--- a/src/website/vite.config.js
+++ b/src/website/vite.config.js
@@ -52,15 +52,38 @@ if (trustResult.status !== 0) {
   );
 }
 
+// Gateway URL the Vite proxy forwards `/api/*` to. The gateway itself
+// stays bound to localhost; only Vite is reachable on the LAN, so the
+// phone only ever sees one origin and one (click-through) cert. The
+// frontend calls same-origin `/api/...` paths via lib/api/gateway.js;
+// the rewrite below strips `/api` before forwarding so the gateway's
+// own routes (`/products`, `/cart/<id>`, `/buy/...`) stay unchanged.
+const GATEWAY_TARGET = 'https://localhost:7126';
+
 export default defineConfig({
   plugins: [sveltekit()],
   server: {
-    host: 'localhost',
+    // host: true binds to 0.0.0.0 so the dev server is reachable from
+    // other devices on the LAN (e.g. a phone) for mobile testing.
+    // Browse to https://<dev-machine-ip>:5173 and click through the
+    // localhost cert warning once per device.
+    host: true,
     port: 5173,
     strictPort: true,
     https: {
       key: fs.readFileSync(keyFilePath),
       cert: fs.readFileSync(certFilePath)
+    },
+    proxy: {
+      '/api': {
+        target: GATEWAY_TARGET,
+        changeOrigin: true,
+        // The gateway cert is the .NET dev cert: valid for `localhost`
+        // only. Vite -> gateway is loopback so we can safely skip TLS
+        // verification on that hop without exposing anything.
+        secure: false,
+        rewrite: (path) => path.replace(/^\/api/, '')
+      }
     }
   }
 });


### PR DESCRIPTION
## Summary

The site was effectively unusable on a phone — the header was misaligned, the filter bar shuffled around at every viewport, the cart row stacked the image, name, qty controls, and Remove across four rows with no spacing, the checkout progress bar overflowed the screen, and the Order Summary sidebar dropped below the main content and pushed the primary action off screen. This branch reworks each of those for phone widths while leaving desktop untouched, and fixes one related bug (the cart `+` button was unbounded).

## What's in this PR

- **LAN-friendly dev server** (`8c73a76`) — Vite binds to `0.0.0.0` and proxies `/api/*` to the gateway, so a phone on the LAN can hit `https://<dev-machine-ip>:5173` with just one cert click-through.
- **Catalog UI** (`07c4cec`) — logo mug/wordmark centered at every viewport; filter bar sort stays pinned right; on mobile the three filter dropdowns collapse behind a single Filters button that opens a bottom sheet.
- **Checkout UI** (`33627ab`) — cart row redesigned for mobile (image sized to column, qty+trash+subtotal on one row, no dead Remove row); progress bar shrinks to fit; OrderSummary sidebar hidden on cart/address/shipping/payment (kept on the summary page where Place Order lives); the cart page gets a compact Order Total pill instead; the shipping page's duplicate items list is hidden.
- **Stock cap** (`f51e825`) — backend now surfaces `InStock` per cart line via the existing InventoryDelta ledger; the `+` button disables once `quantity` reaches the live ceiling.

## Test plan

- [x] Open the site at desktop (≥ 1000 px) and confirm: logo balanced, filter bar with sort flush right, full cart row with text "Remove", Order Summary sidebar present on every checkout step.
- [x] Open the site in Chrome DevTools at iPhone 14 Pro Max (430 × 932) and confirm: header balanced, single Filters button + Sort on one row, Filters opens a bottom sheet, cart row shows `[− qty +] 🗑️  $subtotal` with no Remove row, progress bar fits without scrolling, no OrderSummary sidebar on cart/address/shipping/payment, Order Total pill at the bottom of the cart, summary page still shows the Place Order card.
- [x] On the cart, increase a low-stock item past its ceiling and confirm the `+` button greys out at the right number.