### PR TITLE
♻️ Name quantities by meaning per bounded context

### DIFF
--- a/src/Catalog.Data/Models/Order.cs
+++ b/src/Catalog.Data/Models/Order.cs
@@ -16,9 +16,9 @@ public class Order
 public class OrderItem
 {
     // Composite PK with ProductId; one row per product per order, since
-    // adding the same product again increments Quantity rather than
-    // creating a duplicate row.
+    // adding the same product again increments OrderedQuantity rather
+    // than creating a duplicate row.
     public Guid OrderId { get; set; }
     public Guid ProductId { get; set; }
-    public int Quantity { get; set; }
+    public int OrderedQuantity { get; set; }
 }

--- a/src/Catalog.Data/Seed/SeedData.cs
+++ b/src/Catalog.Data/Seed/SeedData.cs
@@ -129,8 +129,8 @@ public class SeedData
             OrderId = Guid.Parse("08bebbee-0e7e-4368-afab-74f4720f5f4e"),
             Products =
             [
-                new() { Quantity = 2, ProductId = MoersleutelId },
-                new() { Quantity = 1, ProductId = SusanId }
+                new() { OrderedQuantity = 2, ProductId = MoersleutelId },
+                new() { OrderedQuantity = 1, ProductId = SusanId }
             ]
         };
     }

--- a/src/Catalog.Endpoint.Messages/Commands/CompleteOrder.cs
+++ b/src/Catalog.Endpoint.Messages/Commands/CompleteOrder.cs
@@ -9,5 +9,5 @@ public sealed record CompleteOrder
 public sealed record OrderItem
 {
     public required Guid ProductId { get; init; }
-    public required int Quantity { get; init; }
+    public required int OrderedQuantity { get; init; }
 }

--- a/src/Catalog.Endpoint.Messages/Events/OrderPlaced.cs
+++ b/src/Catalog.Endpoint.Messages/Events/OrderPlaced.cs
@@ -18,11 +18,11 @@ public sealed record OrderPlaced
 public sealed record OrderedItem
 {
     public required Guid ProductId { get; init; }
-    public required int Quantity { get; init; }
+    public required int FulfilledQuantity { get; init; }
 }
 
 public sealed record UnfulfilledItem
 {
     public required Guid ProductId { get; init; }
-    public required int Quantity { get; init; }
+    public required int ShortfallQuantity { get; init; }
 }

--- a/src/Catalog.Endpoint/Handlers/CompleteOrderHandler.cs
+++ b/src/Catalog.Endpoint/Handlers/CompleteOrderHandler.cs
@@ -39,7 +39,7 @@ public class CompleteOrderHandler(CatalogDbContext dbContext, ILogger<CompleteOr
         var items = message.Items.Select(i => new OrderItem
         {
             ProductId = i.ProductId,
-            Quantity = i.Quantity
+            OrderedQuantity = i.OrderedQuantity
         });
 
         if (order == null)
@@ -65,21 +65,21 @@ public class CompleteOrderHandler(CatalogDbContext dbContext, ILogger<CompleteOr
         {
             var inStock = await dbContext.InventoryDeltas.CurrentStockAsync(item.ProductId, ct);
 
-            if (inStock < item.Quantity)
+            if (inStock < item.OrderedQuantity)
             {
                 unfulfilled.Add(new UnfulfilledItem
                 {
                     ProductId = item.ProductId,
-                    Quantity = item.Quantity
+                    ShortfallQuantity = item.OrderedQuantity
                 });
             }
             else
             {
-                dbContext.InventoryDeltas.Add(Inventory.Reserve(item.ProductId, item.Quantity));
+                dbContext.InventoryDeltas.Add(Inventory.Reserve(item.ProductId, item.OrderedQuantity));
                 fulfilled.Add(new OrderedItem
                 {
                     ProductId = item.ProductId,
-                    Quantity = item.Quantity
+                    FulfilledQuantity = item.OrderedQuantity
                 });
             }
         }

--- a/src/Catalog.ServiceComposition/Email/Mapper.cs
+++ b/src/Catalog.ServiceComposition/Email/Mapper.cs
@@ -28,7 +28,7 @@ public static class Mapper
         vm.Name = product.Name;
         vm.Description = product.Description;
         vm.ImageUrl = product.ImageUrl;
-        vm.Quantity = orderedProduct.Quantity;
+        vm.Quantity = orderedProduct.OrderedQuantity;
         // Default; Finance flips this to false for items it could not
         // fulfil, in OnOrderEmailProductsLoaded.
         vm.Fulfilled = true;

--- a/src/Catalog.ServiceComposition/Workflow/CompleteOrderWorkflowSlice.cs
+++ b/src/Catalog.ServiceComposition/Workflow/CompleteOrderWorkflowSlice.cs
@@ -42,7 +42,7 @@ public class CompleteOrderWorkflowSlice : WorkflowSlice<CompleteOrderSlice>
                 .Select(i => new OrderItem
                 {
                     ProductId = i.ProductId,
-                    Quantity = i.Quantity
+                    OrderedQuantity = i.Quantity
                 })
                 .ToList()
         };

--- a/src/Finance.Data/Models/Order.cs
+++ b/src/Finance.Data/Models/Order.cs
@@ -26,7 +26,7 @@ public class OrderItem : IPriced
     // parent Order's key when items are added through the navigation.
     public Guid OrderId { get; set; }
     public Guid ProductId { get; set; }
-    public int Quantity { get; set; }
+    public int BillableQuantity { get; set; }
     public decimal Price { get; set; }
     public decimal Discount { get; set; }
 

--- a/src/Finance.Data/Seed/SeedData.cs
+++ b/src/Finance.Data/Seed/SeedData.cs
@@ -104,8 +104,8 @@ public static class SeedData
             },
             Items =
             [
-                new() { ProductId = MoersleutelId, Price = 12m, Quantity = 2 },
-                new() { ProductId = SusanId, Price = 9m, Quantity = 1 }
+                new() { ProductId = MoersleutelId, Price = 12m, BillableQuantity = 2 },
+                new() { ProductId = SusanId, Price = 9m, BillableQuantity = 1 }
             ]
         };
     }

--- a/src/Finance.Endpoint.Messages/Commands/SubmitOrderItems.cs
+++ b/src/Finance.Endpoint.Messages/Commands/SubmitOrderItems.cs
@@ -9,5 +9,5 @@ public sealed record SubmitOrderItems
 public sealed record OrderItem
 {
     public required Guid ProductId { get; init; }
-    public required int Quantity { get; init; }
+    public required int OrderedQuantity { get; init; }
 }

--- a/src/Finance.Endpoint/Handlers/OrderPlacedHandler.cs
+++ b/src/Finance.Endpoint/Handlers/OrderPlacedHandler.cs
@@ -43,7 +43,7 @@ public class OrderPlacedHandler(FinanceDbContext dbContext)
     {
         var itemsTotal = order.Items
             .Where(i => i.Fulfilled)
-            .Sum(i => i.EffectivePrice() * i.Quantity);
+            .Sum(i => i.EffectivePrice() * i.BillableQuantity);
 
         // Shipping is only charged when at least one line shipped. A
         // partial order still pays the full delivery fee - we packed

--- a/src/Finance.Endpoint/Handlers/SubmitOrderItemsHandler.cs
+++ b/src/Finance.Endpoint/Handlers/SubmitOrderItemsHandler.cs
@@ -38,7 +38,7 @@ public class SubmitOrderItemsHandler(FinanceDbContext dbContext)
             order.Items.Add(new OrderItem
             {
                 ProductId = item.ProductId,
-                Quantity = item.Quantity,
+                BillableQuantity = item.OrderedQuantity,
                 Price = product.Price,
                 Discount = product.Discount
             });

--- a/src/Finance.ServiceComposition/Checkout/OnSummaryLoaded.cs
+++ b/src/Finance.ServiceComposition/Checkout/OnSummaryLoaded.cs
@@ -21,7 +21,7 @@ public class OnSummaryLoaded(OrderSubtotalReader orderReader) : ICompositionEven
             if (matchingProduct is null) continue;
             product.Value.Price = matchingProduct.Price;
             product.Value.Discount = matchingProduct.Discount;
-            totalPrice += matchingProduct.EffectivePrice() * matchingProduct.Quantity;
+            totalPrice += matchingProduct.EffectivePrice() * matchingProduct.BillableQuantity;
         }
 
         var vm = request.GetComposedResponseModel();

--- a/src/Finance.ServiceComposition/Email/OrderSummaryComposer.cs
+++ b/src/Finance.ServiceComposition/Email/OrderSummaryComposer.cs
@@ -36,7 +36,7 @@ public class OrderSummaryComposer(FinanceDbContext dbContext, IHttpContextAccess
         // Match the OrderPlacedHandler view: fulfilled items only.
         var itemsSubtotal = order.Items
             .Where(i => i.Fulfilled)
-            .Sum(i => i.EffectivePrice() * i.Quantity);
+            .Sum(i => i.EffectivePrice() * i.BillableQuantity);
 
         dynamic deliveryOptionModel = new ExpandoObject();
         deliveryOptionModel.Price = ShippingFees.EffectivePrice(deliveryOption, itemsSubtotal);

--- a/src/Finance.ServiceComposition/Helpers/OrderSubtotalReader.cs
+++ b/src/Finance.ServiceComposition/Helpers/OrderSubtotalReader.cs
@@ -44,7 +44,7 @@ public class OrderSubtotalReader(FinanceDbContext dbContext, IWorkflowStore work
             {
                 OrderId = orderId,
                 ProductId = line.ProductId,
-                Quantity = line.Quantity
+                BillableQuantity = line.Quantity
             };
             if (prices.TryGetValue(line.ProductId, out var product))
             {
@@ -60,6 +60,6 @@ public class OrderSubtotalReader(FinanceDbContext dbContext, IWorkflowStore work
     public async Task<decimal> GetItemsSubtotalAsync(Guid orderId, CancellationToken ct)
     {
         var order = await GetOrderWithItemsAsync(orderId, ct);
-        return order.Items.Sum(i => i.EffectivePrice() * i.Quantity);
+        return order.Items.Sum(i => i.EffectivePrice() * i.BillableQuantity);
     }
 }

--- a/src/Finance.ServiceComposition/Workflow/OrderItemsWorkflowSlice.cs
+++ b/src/Finance.ServiceComposition/Workflow/OrderItemsWorkflowSlice.cs
@@ -45,7 +45,7 @@ public class OrderItemsWorkflowSlice : WorkflowSlice<OrderItemsSlice>
                 .Select(i => new OrderItem
                 {
                     ProductId = i.ProductId,
-                    Quantity = i.Quantity
+                    OrderedQuantity = i.Quantity
                 })
                 .ToList()
         };

--- a/src/Marketing.Endpoint/Handlers/OrderPlacedHandler.cs
+++ b/src/Marketing.Endpoint/Handlers/OrderPlacedHandler.cs
@@ -41,13 +41,13 @@ public class OrderPlacedHandler(MarketingDbContext dbContext, ILogger<OrderPlace
             dbContext.OrderActivity.Add(new OrderActivity
             {
                 ProductId = item.ProductId,
-                Quantity = item.Quantity,
+                Quantity = item.FulfilledQuantity,
                 OccurredAt = message.OccurredAt
             });
 
             if (products.TryGetValue(item.ProductId, out var product))
             {
-                product.OrderCount += item.Quantity;
+                product.OrderCount += item.FulfilledQuantity;
             }
             else
             {


### PR DESCRIPTION
## Summary

`Quantity` was used identically across Catalog, Finance, and the wire contracts, but it stood for three different concepts: what the customer ordered, what could be fulfilled, and what gets billed. This rename gives each one its own name, so the meaning is obvious at every call site and a mismatch is a compile error rather than a silent bug.

- Wire contracts (`CompleteOrder`, `SubmitOrderItems`) now use `OrderedQuantity` (customer intent).
- `OrderPlaced` distinguishes `FulfilledQuantity` (per `OrderedItem`) from `ShortfallQuantity` (per `UnfulfilledItem`).
- Finance's persisted `OrderItem` stores `BillableQuantity` — the count multiplied by `EffectivePrice()` after the `Fulfilled` flag is applied.
- Catalog's persisted `OrderItem` stays `OrderedQuantity`: it faithfully records the order as received. Actual reservations live on `InventoryDelta` via `Inventory.Reserve`.

Out of scope (intentionally left alone): cart-side `Quantity` (`CartLine`, `CartItemForm`, `AddProductForm`), Marketing's internal `OrderActivity.Quantity` projection, and workflow-slice DTOs that are pure translation plumbing.

## Test plan

- [x] `dotnet build` succeeds with zero warnings/errors
- [x] Place an order through the UI and confirm Catalog reserves stock, Finance charges the right amount, and the email lists the correct quantities
- [x] Place an order that triggers a partial fulfilment (request more than is in stock) and confirm `OrderPlaced` carries the correct `FulfilledQuantity` / `ShortfallQuantity`, the charge reflects only billable lines, and Marketing's `OrderCount` only bumps by what was fulfilled