### PR TITLE
Historical pricing with PriceId lock-in (Finance-only demo)

### DIFF
--- a/src/Finance.Data/FinanceDbContext.cs
+++ b/src/Finance.Data/FinanceDbContext.cs
@@ -6,6 +6,7 @@ namespace Finance.Data;
 public class FinanceDbContext(DbContextOptions<FinanceDbContext> options) : DbContext(options)
 {
     public DbSet<Product> Products => Set<Product>();
+    public DbSet<ProductPrice> ProductPrices => Set<ProductPrice>();
     public DbSet<Order> Orders => Set<Order>();
     public DbSet<OrderItem> OrderItems => Set<OrderItem>();
     public DbSet<DeliveryOption> DeliveryOptions => Set<DeliveryOption>();
@@ -22,6 +23,23 @@ public class FinanceDbContext(DbContextOptions<FinanceDbContext> options) : DbCo
             .WithOne()
             .HasForeignKey(oi => oi.OrderId)
             .OnDelete(DeleteBehavior.Cascade);
+
+        // Append-only price history. PriceId is the PK (picked up by the
+        // <Type>Id convention); each row hangs off its Product.
+        modelBuilder.Entity<Product>()
+            .HasMany(p => p.Prices)
+            .WithOne()
+            .HasForeignKey(pp => pp.ProductId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // An order line points at the immutable price it was billed
+        // against. Restrict on delete: a price that an order references
+        // must not disappear out from under it.
+        modelBuilder.Entity<OrderItem>()
+            .HasOne<ProductPrice>()
+            .WithMany()
+            .HasForeignKey(oi => oi.PriceId)
+            .OnDelete(DeleteBehavior.Restrict);
 
         // BillingAddress is an owned value object: its columns are
         // inlined into the Orders table. Optional so an Order can exist

--- a/src/Finance.Data/FinanceDbContext.cs
+++ b/src/Finance.Data/FinanceDbContext.cs
@@ -24,8 +24,11 @@ public class FinanceDbContext(DbContextOptions<FinanceDbContext> options) : DbCo
             .HasForeignKey(oi => oi.OrderId)
             .OnDelete(DeleteBehavior.Cascade);
 
-        // Append-only price history. PriceId is the PK (picked up by the
-        // <Type>Id convention); each row hangs off its Product.
+        // Append-only price history. PriceId is the PK (set explicitly: the
+        // <Type>Id convention looks for ProductPriceId, not PriceId). Each
+        // row hangs off its Product.
+        modelBuilder.Entity<ProductPrice>().HasKey(pp => pp.PriceId);
+
         modelBuilder.Entity<Product>()
             .HasMany(p => p.Prices)
             .WithOne()

--- a/src/Finance.Data/Models/Order.cs
+++ b/src/Finance.Data/Models/Order.cs
@@ -27,6 +27,11 @@ public class OrderItem : IPriced
     public Guid OrderId { get; set; }
     public Guid ProductId { get; set; }
     public int BillableQuantity { get; set; }
+
+    // The immutable ProductPrice this line was billed against, locked in
+    // at add-to-cart time. Price/Discount below are denormalized from
+    // that row at submit so billing never re-reads the current price.
+    public Guid PriceId { get; set; }
     public decimal Price { get; set; }
     public decimal Discount { get; set; }
 

--- a/src/Finance.Data/Models/Product.cs
+++ b/src/Finance.Data/Models/Product.cs
@@ -1,8 +1,10 @@
 namespace Finance.Data.Models;
 
-public class Product : IPriced
+public class Product
 {
     public Guid ProductId { get; set; }
-    public decimal Price { get; set; }
-    public decimal Discount { get; set; }
+
+    // The product's price history. The current price is the entry with
+    // the highest ValidFrom; see ProductPriceQueries.
+    public List<ProductPrice> Prices { get; set; } = [];
 }

--- a/src/Finance.Data/Models/ProductPrice.cs
+++ b/src/Finance.Data/Models/ProductPrice.cs
@@ -1,0 +1,15 @@
+namespace Finance.Data.Models;
+
+// An immutable, point-in-time price for a product. A price change never
+// updates a row; it appends a new one with a later ValidFrom. The current
+// price for a product is the row with the highest ValidFrom. Orders lock
+// in the PriceId they were placed against, so the amount billed never
+// shifts when a newer price appears.
+public class ProductPrice : IPriced
+{
+    public Guid PriceId { get; set; }
+    public Guid ProductId { get; set; }
+    public decimal Price { get; set; }
+    public decimal Discount { get; set; }
+    public DateTimeOffset ValidFrom { get; set; }
+}

--- a/src/Finance.Data/Models/ProductPricing.cs
+++ b/src/Finance.Data/Models/ProductPricing.cs
@@ -1,8 +1,8 @@
 namespace Finance.Data.Models;
 
 // Anything with a list price and a percentage discount can flow through
-// the centralized pricing rule below. Implemented by Product (the
-// catalog's master record) and OrderItem (the per-line snapshot
+// the centralized pricing rule below. Implemented by ProductPrice (an
+// immutable point-in-time price) and OrderItem (the per-line snapshot
 // captured when a cart is submitted).
 public interface IPriced
 {

--- a/src/Finance.Data/ProductPriceQueries.cs
+++ b/src/Finance.Data/ProductPriceQueries.cs
@@ -1,0 +1,33 @@
+using Finance.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Finance.Data;
+
+// Resolves the "current" price for a product from its append-only price
+// history: the entry with the highest ValidFrom (PriceId breaks ties so
+// the result is deterministic). Demo-scale data, so the latest-per-product
+// pick happens in memory rather than as a translated GROUP BY.
+public static class ProductPriceQueries
+{
+    public static async Task<ProductPrice> CurrentPriceAsync(
+        this FinanceDbContext dbContext, Guid productId, CancellationToken ct)
+    {
+        var rows = await dbContext.ProductPrices
+            .Where(p => p.ProductId == productId)
+            .ToListAsync(ct);
+        return Latest(rows.GroupBy(p => p.ProductId).Single());
+    }
+
+    public static async Task<Dictionary<Guid, ProductPrice>> CurrentPricesAsync(
+        this FinanceDbContext dbContext, IReadOnlyCollection<Guid> productIds, CancellationToken ct)
+    {
+        var rows = await dbContext.ProductPrices
+            .Where(p => productIds.Contains(p.ProductId))
+            .ToListAsync(ct);
+        return rows.GroupBy(p => p.ProductId)
+            .ToDictionary(g => g.Key, Latest);
+    }
+
+    static ProductPrice Latest(IEnumerable<ProductPrice> prices) =>
+        prices.OrderByDescending(p => p.ValidFrom).ThenByDescending(p => p.PriceId).First();
+}

--- a/src/Finance.Data/Seed/DatabaseInitializer.cs
+++ b/src/Finance.Data/Seed/DatabaseInitializer.cs
@@ -14,6 +14,7 @@ public static class DatabaseInitializer
             return;
 
         await dbContext.Products.AddRangeAsync(SeedData.Products(), cancellationToken);
+        await dbContext.ProductPrices.AddRangeAsync(SeedData.ProductPrices(), cancellationToken);
         await dbContext.DeliveryOptions.AddRangeAsync(SeedData.DeliveryOptions(), cancellationToken);
         await dbContext.Orders.AddAsync(SeedData.Orders(), cancellationToken);
 

--- a/src/Finance.Data/Seed/SeedData.cs
+++ b/src/Finance.Data/Seed/SeedData.cs
@@ -43,40 +43,57 @@ public static class SeedData
     static readonly Guid ExpeditedId = Guid.Parse("6e114fc9-aecf-4815-970f-fedbd6709847");
     static readonly Guid PriorityId = Guid.Parse("8008abc4-a60f-4217-9e2c-745aa9af7f2c");
 
-    public static IEnumerable<Product> Products()
-    {
-        return new List<Product>
-        {
-            // PriceId can be random, as it's only used in orders and we don't seed orders
-            new() { ProductId = FremontId, Price = 35, Discount = 0 },
-            new() { ProductId = MoersleutelId, Price = 12, Discount = 0 },
-            new() { ProductId = BarcodeBlackYellowId, Price = 32m, Discount = 0 },
-            new() { ProductId = WhiteDogId, Price = 6, Discount = 0 },
-            new() { ProductId = AbraxasId, Price = 40m, Discount = 0 },
-            new() { ProductId = BourbonCountyId, Price = 25m, Discount = 0 },
-            new() { ProductId = TwentyTwoId, Price = 11m, Discount = 0 },
-            new() { ProductId = SusanId, Price = 9m, Discount = 10 },
-            new() { ProductId = TiarnaId, Price = 12m, Discount = 0 },
-            new() { ProductId = BlueBerryMuffinId, Price = 8m, Discount = 20 },
-            new() { ProductId = OudeGeuzeId, Price = 16m, Discount = 0 },
+    static readonly DateTimeOffset SeededAt = new(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
-            new() { ProductId = ExtravagantChocolateId, Price = 9.50m, Discount = 0 },
-            new() { ProductId = Indulgence16Id, Price = 26.95m, Discount = 0 },
-            new() { ProductId = Indulgence28Id, Price = 29.95m, Discount = 0 },
-            new() { ProductId = KbbsId, Price = 474.95m, Discount = 0 },
-            new() { ProductId = SunflowersId, Price = 67.50m, Discount = 0 },
-            new() { ProductId = BlueSuedeShewsId, Price = 579.95m, Discount = 0 },
-            new() { ProductId = GalaxyFortPointId, Price = 25.90m, Discount = 0 },
-            new() { ProductId = MosaicFortPointId, Price = 13.90m, Discount = 0 },
-            new() { ProductId = PseudoSueId, Price = 8.75m, Discount = 0 },
-            new() { ProductId = LaTrappeQuad50Id, Price = 34.95m, Discount = 0 },
-            new() { ProductId = ChickenBroccoliId, Price = 4.92m, Discount = 0 },
-            new() { ProductId = TripleFruitBombId, Price = 4.99m, Discount = 0 },
-            new() { ProductId = CoastalSunshineId, Price = 9.99m, Discount = 0 },
-            new() { ProductId = JuiceLandV4Id, Price = 13.98m, Discount = 0 },
-            new() { ProductId = DoubleMosaicDreamId, Price = 9.99m, Discount = 0 },
+    // One current price per product. PriceId is generated per seed run;
+    // seeding only runs against an empty database and orders reference
+    // these rows by PriceId within the same run, so stable ids across
+    // runs aren't needed.
+    static readonly IReadOnlyList<ProductPrice> ProductPriceSeed =
+    [
+        Price(FremontId, 35, 0),
+        Price(MoersleutelId, 12, 0),
+        Price(BarcodeBlackYellowId, 32m, 0),
+        Price(WhiteDogId, 6, 0),
+        Price(AbraxasId, 40m, 0),
+        Price(BourbonCountyId, 25m, 0),
+        Price(TwentyTwoId, 11m, 0),
+        Price(SusanId, 9m, 10),
+        Price(TiarnaId, 12m, 0),
+        Price(BlueBerryMuffinId, 8m, 20),
+        Price(OudeGeuzeId, 16m, 0),
+
+        Price(ExtravagantChocolateId, 9.50m, 0),
+        Price(Indulgence16Id, 26.95m, 0),
+        Price(Indulgence28Id, 29.95m, 0),
+        Price(KbbsId, 474.95m, 0),
+        Price(SunflowersId, 67.50m, 0),
+        Price(BlueSuedeShewsId, 579.95m, 0),
+        Price(GalaxyFortPointId, 25.90m, 0),
+        Price(MosaicFortPointId, 13.90m, 0),
+        Price(PseudoSueId, 8.75m, 0),
+        Price(LaTrappeQuad50Id, 34.95m, 0),
+        Price(ChickenBroccoliId, 4.92m, 0),
+        Price(TripleFruitBombId, 4.99m, 0),
+        Price(CoastalSunshineId, 9.99m, 0),
+        Price(JuiceLandV4Id, 13.98m, 0),
+        Price(DoubleMosaicDreamId, 9.99m, 0),
+    ];
+
+    static ProductPrice Price(Guid productId, decimal price, decimal discount) =>
+        new()
+        {
+            PriceId = Guid.NewGuid(),
+            ProductId = productId,
+            Price = price,
+            Discount = discount,
+            ValidFrom = SeededAt
         };
-    }
+
+    public static IEnumerable<Product> Products() =>
+        ProductPriceSeed.Select(p => new Product { ProductId = p.ProductId });
+
+    public static IEnumerable<ProductPrice> ProductPrices() => ProductPriceSeed;
 
     public static IEnumerable<DeliveryOption> DeliveryOptions()
     {
@@ -104,9 +121,24 @@ public static class SeedData
             },
             Items =
             [
-                new() { ProductId = MoersleutelId, Price = 12m, BillableQuantity = 2 },
-                new() { ProductId = SusanId, Price = 9m, BillableQuantity = 1 }
+                LineFor(MoersleutelId, 2),
+                LineFor(SusanId, 1)
             ]
+        };
+    }
+
+    // A seeded order line snapshots Price/Discount from the locked price
+    // and records the PriceId, exactly as SubmitOrderItemsHandler does.
+    static OrderItem LineFor(Guid productId, int quantity)
+    {
+        var price = ProductPriceSeed.First(p => p.ProductId == productId);
+        return new OrderItem
+        {
+            ProductId = productId,
+            PriceId = price.PriceId,
+            Price = price.Price,
+            Discount = price.Discount,
+            BillableQuantity = quantity
         };
     }
 }

--- a/src/Finance.Endpoint.Messages/Commands/SubmitOrderItems.cs
+++ b/src/Finance.Endpoint.Messages/Commands/SubmitOrderItems.cs
@@ -10,4 +10,5 @@ public sealed record OrderItem
 {
     public required Guid ProductId { get; init; }
     public required int OrderedQuantity { get; init; }
+    public required Guid PriceId { get; init; }
 }

--- a/src/Finance.Endpoint/Handlers/SubmitOrderItemsHandler.cs
+++ b/src/Finance.Endpoint/Handlers/SubmitOrderItemsHandler.cs
@@ -25,22 +25,25 @@ public class SubmitOrderItemsHandler(FinanceDbContext dbContext)
             order.Items.Clear();
         }
 
-        // NOTE: Never ever do this! Don't retrieve _current_ price after submitting the order.
-        // Instead, use attached PriceId. But that isn't implemented yet.
-        var productIds = message.Items.Select(i => i.ProductId).ToList();
-        var products = await dbContext.Products
-            .Where(p => productIds.Contains(p.ProductId))
-            .ToDictionaryAsync(p => p.ProductId, context.CancellationToken);
+        // Bill against the exact price the customer saw: resolve the
+        // immutable ProductPrice by the PriceId locked in at add-to-cart,
+        // never the current price. A newer price added since then is a
+        // separate row this lookup ignores.
+        var priceIds = message.Items.Select(i => i.PriceId).ToList();
+        var prices = await dbContext.ProductPrices
+            .Where(p => priceIds.Contains(p.PriceId))
+            .ToDictionaryAsync(p => p.PriceId, context.CancellationToken);
 
         foreach (var item in message.Items)
         {
-            var product = products[item.ProductId];
+            var price = prices[item.PriceId];
             order.Items.Add(new OrderItem
             {
                 ProductId = item.ProductId,
                 BillableQuantity = item.OrderedQuantity,
-                Price = product.Price,
-                Discount = product.Discount
+                PriceId = item.PriceId,
+                Price = price.Price,
+                Discount = price.Discount
             });
         }
 

--- a/src/Finance.ServiceComposition/Cart/CartPricesWorkflowSlice.cs
+++ b/src/Finance.ServiceComposition/Cart/CartPricesWorkflowSlice.cs
@@ -1,0 +1,25 @@
+using WorkflowComposer;
+
+namespace Finance.ServiceComposition.Cart;
+
+// The PriceId the customer saw, captured per product as items are added
+// to the in-flight cart. Finance-owned and Finance-keyed: it lives
+// alongside Catalog's own CartSlice under the same orderId but is never
+// read or written by Catalog. OrderSubmitComposer joins each submitted
+// line to this slice to lock the price in. Capture-only, so it emits no
+// command of its own.
+public sealed record CartPricesSlice(IReadOnlyList<CartPriceLine> Items)
+{
+    public static CartPricesSlice Empty { get; } = new([]);
+}
+
+public sealed record CartPriceLine(Guid ProductId, Guid PriceId);
+
+public class CartPricesWorkflowSlice : WorkflowSlice<CartPricesSlice>
+{
+    public const string Key = "Finance.CartPrices";
+
+    public override string SliceKey => Key;
+
+    protected override object? BuildSubmitCommand(Guid orderId, CartPricesSlice slice) => null;
+}

--- a/src/Finance.ServiceComposition/Cart/OnCartLoaded.cs
+++ b/src/Finance.ServiceComposition/Cart/OnCartLoaded.cs
@@ -2,7 +2,6 @@ using Catalog.ServiceComposition.Events;
 using Finance.Data;
 using Finance.Data.Models;
 using Microsoft.AspNetCore.Http;
-using Microsoft.EntityFrameworkCore;
 using ServiceComposer.AspNetCore;
 
 namespace Finance.ServiceComposition.Cart;
@@ -12,18 +11,17 @@ public class OnCartLoaded(FinanceDbContext dbContext) : ICompositionEventsHandle
     public async Task Handle(CartLoaded @event, HttpRequest request)
     {
         var productIds = @event.OrderedProducts.Keys.ToList();
-        var resultSet = await dbContext.Products
-            .Where(s => productIds.Contains(s.ProductId))
-            .ToListAsync(request.HttpContext.RequestAborted);
+        var prices = await dbContext.CurrentPricesAsync(productIds, request.HttpContext.RequestAborted);
 
         decimal totalPrice = 0;
         foreach (var product in @event.OrderedProducts)
         {
-            var matchingProduct = resultSet.Single(s => s.ProductId == product.Key);
-            product.Value.Price = matchingProduct.Price;
-            product.Value.Discount = matchingProduct.Discount;
+            var price = prices[product.Key];
+            product.Value.PriceId = price.PriceId;
+            product.Value.Price = price.Price;
+            product.Value.Discount = price.Discount;
 
-            totalPrice += matchingProduct.EffectivePrice() * (int)product.Value.Quantity;
+            totalPrice += price.EffectivePrice() * (int)product.Value.Quantity;
         }
 
         var vm = request.GetComposedResponseModel();

--- a/src/Finance.ServiceComposition/Cart/OnCartSummaryLoaded.cs
+++ b/src/Finance.ServiceComposition/Cart/OnCartSummaryLoaded.cs
@@ -2,14 +2,13 @@ using Catalog.ServiceComposition.Events;
 using Finance.Data;
 using Finance.Data.Models;
 using Microsoft.AspNetCore.Http;
-using Microsoft.EntityFrameworkCore;
 using ServiceComposer.AspNetCore;
 
 namespace Finance.ServiceComposition.Cart;
 
 // Companion to `CartSummaryComposer` on the Catalog side: receives
 // `CartSummaryLoaded`, attaches per-item Price/Discount from Finance's
-// Products view, and exposes the cart total. The shipping route uses
+// current price view, and exposes the cart total. The shipping route uses
 // the heavier `OnCartLoaded` / `CartLoaded` pair instead, because
 // it also renders product names/images.
 public class OnCartSummaryLoaded(FinanceDbContext dbContext) : ICompositionEventsHandler<CartSummaryLoaded>
@@ -17,18 +16,17 @@ public class OnCartSummaryLoaded(FinanceDbContext dbContext) : ICompositionEvent
     public async Task Handle(CartSummaryLoaded @event, HttpRequest request)
     {
         var productIds = @event.OrderedProducts.Keys.ToList();
-        var resultSet = await dbContext.Products
-            .Where(p => productIds.Contains(p.ProductId))
-            .ToListAsync(request.HttpContext.RequestAborted);
+        var prices = await dbContext.CurrentPricesAsync(productIds, request.HttpContext.RequestAborted);
 
         decimal totalPrice = 0;
         foreach (var product in @event.OrderedProducts)
         {
-            var matchingProduct = resultSet.Single(p => p.ProductId == product.Key);
-            product.Value.Price = matchingProduct.Price;
-            product.Value.Discount = matchingProduct.Discount;
+            var price = prices[product.Key];
+            product.Value.PriceId = price.PriceId;
+            product.Value.Price = price.Price;
+            product.Value.Discount = price.Discount;
 
-            totalPrice += matchingProduct.EffectivePrice() * (int)product.Value.Quantity;
+            totalPrice += price.EffectivePrice() * (int)product.Value.Quantity;
         }
 
         var vm = request.GetComposedResponseModel();

--- a/src/Finance.ServiceComposition/Cart/ShoppingCartAddItemPriceComposer.cs
+++ b/src/Finance.ServiceComposition/Cart/ShoppingCartAddItemPriceComposer.cs
@@ -1,0 +1,68 @@
+using System.Text.Json;
+using Finance.Data;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using ServiceComposer.AspNetCore;
+using WorkflowComposer;
+
+namespace Finance.ServiceComposition.Cart;
+
+// Co-runs with Catalog's ShoppingCartAddItemComposer on the same route.
+// Catalog records ProductId + Quantity in its CartSlice; Finance records
+// the PriceId the customer saw in its own CartPricesSlice, so the price
+// is locked the moment the item enters the cart. Reads the buffered body
+// directly (ServiceComposer enables buffering) and rewinds first so the
+// other composer still sees JSON.
+[CompositionHandler]
+public class ShoppingCartAddItemPriceComposer(
+    IWorkflowStore workflow,
+    FinanceDbContext dbContext,
+    IHttpContextAccessor http)
+{
+    static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    [HttpPost("/cart/addproduct/{orderId}")]
+    public async Task Handle(Guid orderId)
+    {
+        var request = http.HttpContext!.Request;
+        var ct = request.HttpContext.RequestAborted;
+
+        request.Body.Position = 0;
+        var form = await JsonSerializer.DeserializeAsync<AddProductPriceForm>(request.Body, JsonOptions, ct);
+        if (form is null || form.Id == Guid.Empty)
+            return;
+
+        var slice = await workflow.Read<CartPricesSlice>(orderId, CartPricesWorkflowSlice.Key, ct)
+                    ?? CartPricesSlice.Empty;
+
+        var priceId = await ResolvePriceId(form, slice, ct);
+
+        var lines = slice.Items.Where(l => l.ProductId != form.Id).ToList();
+        lines.Add(new CartPriceLine(form.Id, priceId));
+        await workflow.Write(orderId, CartPricesWorkflowSlice.Key, new CartPricesSlice(lines), ct);
+    }
+
+    // The on-screen PriceId forwarded by the UI is authoritative. When it
+    // is absent (e.g. a quantity tweak from the cart page posts only
+    // id+quantity), keep the price already locked for this product;
+    // only resolve the current price when nothing has been captured yet.
+    async Task<Guid> ResolvePriceId(AddProductPriceForm form, CartPricesSlice slice, CancellationToken ct)
+    {
+        if (form.PriceId != Guid.Empty)
+            return form.PriceId;
+
+        var existing = slice.Items.FirstOrDefault(l => l.ProductId == form.Id);
+        if (existing is not null)
+            return existing.PriceId;
+
+        var current = await dbContext.CurrentPriceAsync(form.Id, ct);
+        return current.PriceId;
+    }
+
+    sealed class AddProductPriceForm
+    {
+        public Guid Id { get; set; }
+        public int Quantity { get; set; }
+        public Guid PriceId { get; set; }
+    }
+}

--- a/src/Finance.ServiceComposition/Checkout/OrderSubmitComposer.cs
+++ b/src/Finance.ServiceComposition/Checkout/OrderSubmitComposer.cs
@@ -1,4 +1,6 @@
 using System.Text.Json;
+using Finance.Data;
+using Finance.ServiceComposition.Cart;
 using Finance.ServiceComposition.Workflow;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -11,7 +13,7 @@ namespace Finance.ServiceComposition.Checkout;
 // request.Body rather than via [FromBody]. See Catalog's matching
 // OrderSubmitComposer for the rationale.
 [CompositionHandler]
-public class OrderSubmitComposer(IWorkflowStore workflow, IHttpContextAccessor http)
+public class OrderSubmitComposer(IWorkflowStore workflow, FinanceDbContext dbContext, IHttpContextAccessor http)
 {
     static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
@@ -26,9 +28,20 @@ public class OrderSubmitComposer(IWorkflowStore workflow, IHttpContextAccessor h
         request.Body.Position = 0;
         var items = await JsonSerializer.DeserializeAsync<List<CartItemForm>>(request.Body, JsonOptions, ct) ?? [];
 
-        var slice = new OrderItemsSlice(items
-            .Select(i => new OrderItemLine(i.ProductId, i.Quantity))
-            .ToList());
-        await workflow.Write(orderId, OrderItemsWorkflowSlice.Key, slice, ct);
+        // Attach the PriceId locked at add-to-cart. A line missing one (e.g.
+        // a quantity edited before this slice existed) falls back to current.
+        var captured = await workflow.Read<CartPricesSlice>(orderId, CartPricesWorkflowSlice.Key, ct)
+                       ?? CartPricesSlice.Empty;
+        var lockedPriceIds = captured.Items.ToDictionary(l => l.ProductId, l => l.PriceId);
+
+        var lines = new List<OrderItemLine>(items.Count);
+        foreach (var item in items)
+        {
+            if (!lockedPriceIds.TryGetValue(item.ProductId, out var priceId))
+                priceId = (await dbContext.CurrentPriceAsync(item.ProductId, ct)).PriceId;
+            lines.Add(new OrderItemLine(item.ProductId, item.Quantity, priceId));
+        }
+
+        await workflow.Write(orderId, OrderItemsWorkflowSlice.Key, new OrderItemsSlice(lines), ct);
     }
 }

--- a/src/Finance.ServiceComposition/Helpers/OrderSubtotalReader.cs
+++ b/src/Finance.ServiceComposition/Helpers/OrderSubtotalReader.cs
@@ -12,10 +12,10 @@ namespace Finance.ServiceComposition.Helpers;
 // Composers run in two phases of the checkout. Pre-submit there is no
 // persisted Order yet (SubmitOrderItems is dispatched together with
 // CompleteOrder), so items live in the workflow slice and are priced
-// against the current Finance.Products row. Post-submit the persisted
-// Order.Items is the snapshot at submit time. Both paths return
-// OrderItems whose Price/Discount/Quantity feed the same downstream
-// subtotal math.
+// against the PriceId locked into that slice at add-to-cart. Post-submit
+// the persisted Order.Items is the snapshot at submit time. Both paths
+// return OrderItems whose Price/Discount/Quantity feed the same
+// downstream subtotal math.
 public class OrderSubtotalReader(FinanceDbContext dbContext, IWorkflowStore workflow)
 {
     public async Task<Order> GetOrderWithItemsAsync(Guid orderId, CancellationToken ct)
@@ -33,10 +33,10 @@ public class OrderSubtotalReader(FinanceDbContext dbContext, IWorkflowStore work
         if (slice is null || slice.Items.Count == 0)
             return order;
 
-        var productIds = slice.Items.Select(i => i.ProductId).ToList();
-        var prices = await dbContext.Products
-            .Where(p => productIds.Contains(p.ProductId))
-            .ToDictionaryAsync(p => p.ProductId, ct);
+        var priceIds = slice.Items.Select(i => i.PriceId).ToList();
+        var prices = await dbContext.ProductPrices
+            .Where(p => priceIds.Contains(p.PriceId))
+            .ToDictionaryAsync(p => p.PriceId, ct);
 
         foreach (var line in slice.Items)
         {
@@ -44,12 +44,13 @@ public class OrderSubtotalReader(FinanceDbContext dbContext, IWorkflowStore work
             {
                 OrderId = orderId,
                 ProductId = line.ProductId,
+                PriceId = line.PriceId,
                 BillableQuantity = line.Quantity
             };
-            if (prices.TryGetValue(line.ProductId, out var product))
+            if (prices.TryGetValue(line.PriceId, out var price))
             {
-                item.Price = product.Price;
-                item.Discount = product.Discount;
+                item.Price = price.Price;
+                item.Discount = price.Discount;
             }
             order.Items.Add(item);
         }

--- a/src/Finance.ServiceComposition/Products/OnProductLoaded.cs
+++ b/src/Finance.ServiceComposition/Products/OnProductLoaded.cs
@@ -1,7 +1,6 @@
 using Catalog.ServiceComposition.Events;
 using Finance.Data;
 using Microsoft.AspNetCore.Http;
-using Microsoft.EntityFrameworkCore;
 using ServiceComposer.AspNetCore;
 
 namespace Finance.ServiceComposition.Products;
@@ -10,10 +9,11 @@ public class OnProductLoaded(FinanceDbContext dbContext) : ICompositionEventsHan
 {
     public async Task Handle(ProductLoaded @event, HttpRequest request)
     {
-        var product = await dbContext.Products
-            .SingleAsync(s => s.ProductId == @event.ProductId, request.HttpContext.RequestAborted);
+        var price = await dbContext.CurrentPriceAsync(@event.ProductId, request.HttpContext.RequestAborted);
 
-        @event.Product.Price = product.Price;
-        @event.Product.Discount = product.Discount;
+        // PriceId is the on-screen price the cart locks in at add time.
+        @event.Product.PriceId = price.PriceId;
+        @event.Product.Price = price.Price;
+        @event.Product.Discount = price.Discount;
     }
 }

--- a/src/Finance.ServiceComposition/Products/OnProductsLoaded.cs
+++ b/src/Finance.ServiceComposition/Products/OnProductsLoaded.cs
@@ -1,7 +1,6 @@
 using Catalog.ServiceComposition.Events;
 using Finance.Data;
 using Microsoft.AspNetCore.Http;
-using Microsoft.EntityFrameworkCore;
 using ServiceComposer.AspNetCore;
 
 namespace Finance.ServiceComposition.Products;
@@ -11,15 +10,14 @@ class OnProductsLoaded(FinanceDbContext dbContext) : ICompositionEventsHandler<P
     public async Task Handle(ProductsLoaded @event, HttpRequest request)
     {
         var productIds = @event.Products.Keys.ToList();
-        var resultSet = await dbContext.Products
-            .Where(s => productIds.Contains(s.ProductId))
-            .ToListAsync(request.HttpContext.RequestAborted);
+        var prices = await dbContext.CurrentPricesAsync(productIds, request.HttpContext.RequestAborted);
 
         foreach (var product in @event.Products)
         {
-            var matchingProduct = resultSet.Single(s => s.ProductId == product.Key);
-            product.Value.Price = matchingProduct.Price;
-            product.Value.Discount = matchingProduct.Discount;
+            var price = prices[product.Key];
+            product.Value.PriceId = price.PriceId;
+            product.Value.Price = price.Price;
+            product.Value.Discount = price.Discount;
         }
     }
 }

--- a/src/Finance.ServiceComposition/Workflow/OrderItemsWorkflowSlice.cs
+++ b/src/Finance.ServiceComposition/Workflow/OrderItemsWorkflowSlice.cs
@@ -13,7 +13,7 @@ public sealed record OrderItemsSlice(IReadOnlyList<OrderItemLine> Items)
     public static OrderItemsSlice Empty { get; } = new([]);
 }
 
-public sealed record OrderItemLine(Guid ProductId, int Quantity);
+public sealed record OrderItemLine(Guid ProductId, int Quantity, Guid PriceId);
 
 public class OrderItemsWorkflowSlice : WorkflowSlice<OrderItemsSlice>
 {
@@ -45,7 +45,8 @@ public class OrderItemsWorkflowSlice : WorkflowSlice<OrderItemsSlice>
                 .Select(i => new OrderItem
                 {
                     ProductId = i.ProductId,
-                    OrderedQuantity = i.Quantity
+                    OrderedQuantity = i.Quantity,
+                    PriceId = i.PriceId
                 })
                 .ToList()
         };

--- a/src/website/src/routes/product/[productId]/+page.svelte
+++ b/src/website/src/routes/product/[productId]/+page.svelte
@@ -42,7 +42,8 @@
       const cartId = orderId.ensure();
       const result = await gateway.addProductToCart(cartId, {
         id: productId,
-        quantity
+        quantity,
+        priceId: product.priceId
       });
       if (result?.orderId) orderId.set(result.orderId);
       await refreshCartCount(get(orderId));


### PR DESCRIPTION
> **Illustrative demonstration — do not merge.** This PR exists to make an architecture point, not to ship.

## The point

A change to *how pricing works* lands almost entirely inside the **Finance** service. The diff is `src/Finance.*` plus a **single line** in the website. No change to Catalog, Shipping, PaymentInfo, Marketing, the workflow engine, or the gateway.

## The problem

`Finance.Endpoint/Handlers/SubmitOrderItemsHandler.cs` used to read the *current* product price when the async message was handled, not when the customer ordered. If a price changed in between, the customer was billed the wrong amount. The handler even admitted it:

```csharp
// NOTE: Never ever do this! Don't retrieve _current_ price after submitting the order.
// Instead, use attached PriceId. But that isn't implemented yet.
```

## The fix

- **Prices become an immutable, append-only time series**: `ProductPrice`, each row carrying its own `PriceId`. "Current price" is the latest row by `ValidFrom`; `Product.Price`/`Discount` are gone.
- **The PriceId the customer saw is locked in at add-to-cart**: the UI forwards the on-screen `priceId`, and a Finance composer co-running on `POST /cart/addproduct/{orderId}` captures it into a Finance-owned `Finance.CartPrices` slice.
- It is threaded through Finance's own `SubmitOrderItems` command and resolved **strictly by `PriceId`** (never "current") in the handler. Async handling and the confirmation email now always bill exactly what the customer saw, even after a newer price is added.

## Why only one line lives outside Finance

Locking the price at the moment of add-to-cart needs the UI to pass along the `priceId` it already renders:

```diff
  const result = await gateway.addProductToCart(cartId, {
    id: productId,
-   quantity
+   quantity,
+   priceId: product.priceId
  });
```

That is the entire non-Finance footprint. Everything else — the historical model, capture, threading, billing — is Finance's own.

### Prerequisite (already on `main`)

A small, separate change established cart identity in the frontend (the client mints the cart `orderId` up front) so every composer sees the same id, and Catalog stopped minting it server-side. It landed independently so it is not noise here.

## What this PR does **not** touch

`src/Catalog.*`, `src/Shipping.*`, `src/PaymentInfo.*`, `src/Marketing.*`, `src/WorkflowComposer*`, `src/CompositionGateway`, the `CompleteOrder` contract, and Catalog's `CartSlice`. `git diff --stat main...` is the headline artifact.

## Demo walkthrough

1. Run the stack (the **Website + AllInOne** compound, or gateway + endpoints + website). For a fresh schema, delete `src/.db/finance.db` so the new `ProductPrice` table and seed are created on startup.
2. Browse a beer and add it to the cart — a `Finance.CartPrices` entry is written under the cart's id, carrying the on-screen PriceId.
3. Proceed through checkout and place the order.
4. Simulate a price change *after* add-to-cart by inserting a newer `ProductPrice` row for that product.
5. Confirm the order total and the confirmation email reflect the **old, locked** price (resolved via the order's `PriceId`), not the new current price.

## Commits

- Model product prices as an immutable time series
- Lock in the PriceId the customer saw at add-to-cart
- Bill orders by locked PriceId, not the current price
- Configure ProductPrice primary key explicitly